### PR TITLE
Add links to commits to status

### DIFF
--- a/src/Pack/Admin/Report/Types.idr
+++ b/src/Pack/Admin/Report/Types.idr
@@ -45,8 +45,9 @@ Monoid RepLines where
   neutral = MkRL Lin Lin Lin
 
 ghCommitLink : URL -> Commit -> String
-ghCommitLink u c  =
- "[\{c}](\{u}/commit/\{c})"
+ghCommitLink u c@(MkCommit commit)  =
+  let shortSha = substr 0 7 commit in
+ "[\{shortSha}](\{u}/commit/\{c})"
 
 succLine : ResolvedPackage -> Maybe String
 succLine (RGitHub n u c _ d) =

--- a/src/Pack/Admin/Report/Types.idr
+++ b/src/Pack/Admin/Report/Types.idr
@@ -44,16 +44,20 @@ Semigroup RepLines where
 Monoid RepLines where
   neutral = MkRL Lin Lin Lin
 
+ghCommitLink : URL -> Commit -> String
+ghCommitLink u c  =
+ "[\{c}](\{u}/commit/\{c})"
+
 succLine : ResolvedPackage -> Maybe String
 succLine (RGitHub n u c _ d) =
   let desc = fromMaybe "" d.brief
-   in Just "| [\{n}](\{u}) | \{desc} | \{c} |"
+   in Just "| [\{n}](\{u}) | \{desc} | \{ghCommitLink u c} |"
 succLine _ = Nothing
 
 failLine : (ResolvedPackage, List PkgName) -> Maybe String
 failLine (RGitHub n u c _ _, ps) =
   let deps = fastConcat . intersperse ", " $ map interpolate ps
-   in Just "| [\{n}](\{u}) | \{deps} | \{c} |"
+  in Just "| [\{n}](\{u}) | \{deps} | \{ghCommitLink u c} |"
 failLine _ = Nothing
 
 errLine : (PkgName, PackErr) -> String


### PR DESCRIPTION
Could make it stlightly easier to track down exactly what is included in package set. This link format might be specific to Github, though it looks like Gitlab also supports `\{url}/commit/\{sha}`. Not sure about other source code hosting, but the data constructor is named RGithub after all.