### PR TITLE
Only publish docker image on schedule

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,11 +1,6 @@
 name: Docker Build
 
 on:
-  push:
-    branches:
-      - '**'
-    tags:
-      - '**'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Can maybe change this in future to publish something on main, and build
the `nightly-*` tags on the schedule, but this should be good enough for
now.