### PR TITLE
[ new ] support meta commits

### DIFF
--- a/src/Pack/Config/TOML.idr
+++ b/src/Pack/Config/TOML.idr
@@ -19,7 +19,7 @@ FromTOML Codegen where
 
 ||| Adj configuration.
 export
-config : Value -> Either TOMLErr (Config_ Maybe Nothing)
+config : Value -> Either TOMLErr (Config_ MetaCommit Maybe Nothing)
 config v =
   [| MkConfig (pure Nothing)
               (maybeValAt "collection" v)

--- a/src/Pack/Database/TOML.idr
+++ b/src/Pack/Database/TOML.idr
@@ -9,25 +9,28 @@ import Pack.Database.Types
 
 %default total
 
-github : Value -> Either TOMLErr Package
+export
+FromTOML MetaCommit where fromTOML = tmap fromString
+
+github : FromTOML c => Value -> Either TOMLErr (Package_ c)
 github v = [| GitHub (valAt "url" v)
                      (valAt "commit" v)
                      (valAt "ipkg" v)
                      (optValAt "packagePath" False v) |]
 
-local : Value -> Either TOMLErr Package
+local : Value -> Either TOMLErr (Package_ c)
 local v = [| Local (valAt "path" v)
                    (valAt "ipkg" v)
                    (optValAt "packagePath" False v) |]
 
-package : Value -> Either TOMLErr Package
+package : FromTOML c => Value -> Either TOMLErr (Package_ c)
 package v = valAt {a = String} "type" v >>=
   \case "github" => github v
         "local"  => local v
         _        => Left $ WrongType ["type"] "Package Type"
 
 export %inline
-FromTOML Package where
+FromTOML c => FromTOML (Package_ c) where
   fromTOML = package
 
 ||| URL of the Idris repository


### PR DESCRIPTION
This implements #96  . It is now possible to add a `latest` meta commit to custom packages in the `pack.toml` files. Pack will then resolve the package by fetching the latest commit from the given branch. Packages will be (re)installed as needed. Here's the syntax to use:

```toml
[custom.all.rio]
type   = "github"
url    = "https://github.com/stefan-hoeck/idris2-rio"
commit = "latest:sys"
ipkg   = "rio.ipkg"
```