### PR TITLE
[ new ] support switching to latest collection

### DIFF
--- a/src/Pack/CmdLn/Completion.idr
+++ b/src/Pack/CmdLn/Completion.idr
@@ -127,7 +127,8 @@ opts x "run"              e = prefixOnlyIfNonEmpty x <$> packagesOrIpkg e
 opts x "install"          e = prefixOnlyIfNonEmpty x <$> pure (packages e)
 opts x "install-app"      e = prefixOnlyIfNonEmpty x <$> pure (packages e)
 opts x "remove"           e = prefixOnlyIfNonEmpty x <$> installedPackages e
-opts x "switch"           e = prefixOnlyIfNonEmpty x <$> collections e
+opts x "switch"           e =   prefixOnlyIfNonEmpty x . ("latest" ::)
+                            <$> collections e
 opts x "typecheck"        e = prefixOnlyIfNonEmpty x <$> ipkgFiles
 
 -- options

--- a/src/Pack/CmdLn/Opts.idr
+++ b/src/Pack/CmdLn/Opts.idr
@@ -221,6 +221,12 @@ usageInfo = """
       `$HOME/.pack/bin`, which you can then include in your
       `$PATH` variable.
 
+      Note: It is also possible to switch to the latest package
+      collection by using "latest" as the collection name. This will
+      automatically update the data collection, select the latest
+      nightly, and change the `collection =` entry in the global
+      `pack.toml` file.
+
     info
       Print general information about the current package
       collection and list installed applications and libraries.

--- a/src/Pack/Config/Env.idr
+++ b/src/Pack/Config/Env.idr
@@ -153,3 +153,16 @@ env : HasIO io => Config s -> EitherT PackErr io (Env DBLoaded)
 env conf = do
   db <- loadDB conf
   pure $ {db := db} conf
+
+adjCollection : DBName -> String -> String
+adjCollection db str = case isPrefixOf "collection " str of
+  False => str
+  True  => "collection = \"\{db}\""
+
+export covering
+writeCollection : HasIO io => Config s -> EitherT PackErr io ()
+writeCollection c =
+  let toml = configPath c.packDir
+   in do
+     str <- read toml
+     write toml (unlines . map (adjCollection c.collection) $ lines str)

--- a/src/Pack/Runner.idr
+++ b/src/Pack/Runner.idr
@@ -39,4 +39,5 @@ runCmd = do
       db  <- defaultColl c.packDir
       env <- idrisEnv ({collection := db} c)
       links env
+      writeCollection env
     Switch db          => idrisEnv ({collection := db} c) >>= links

--- a/src/Pack/Runner.idr
+++ b/src/Pack/Runner.idr
@@ -33,5 +33,10 @@ runCmd = do
     PackagePath        => env c >>= putStrLn . packagePathDirs
     LibsPath           => env c >>= putStrLn . packageLibDirs
     DataPath           => env c >>= putStrLn . packageDataDirs
-    Switch db          => idrisEnv ({collection := db} c) >>= links
     Info               => env c >>= printInfo
+    Switch "latest"    => do
+      updateDB c
+      db  <- defaultColl c.packDir
+      env <- idrisEnv ({collection := db} c)
+      links env
+    Switch db          => idrisEnv ({collection := db} c) >>= links


### PR DESCRIPTION
This allows us to use `pack switch latest`, which will then update the data collections, select the latest nightly and install all auto-libs and apps, rewire the `bin` symlink, and adjust the `collection` entry in the global `pack.toml` in one fell swoop. Highly useful for people living on the bleeding edge.