### PR TITLE
[ performance ] less commit fetching

### DIFF
--- a/src/Pack/Admin/Runner.idr
+++ b/src/Pack/Admin/Runner.idr
@@ -41,7 +41,7 @@ Command ACmd where
 covering
 commitOf : HasIO io => Package -> EitherT PackErr io Package
 commitOf (GitHub url branch ipkg pp) = do
-  commit <- gitLatest url branch
+  commit <- gitLatest url (MkBranch branch.value)
   pure $ GitHub url commit ipkg pp
 commitOf p                        = pure p
 
@@ -69,7 +69,7 @@ runCmd = do
   pd       <- getPackDir
   pd       <- CD <$> curDir
   (mc,cmd) <- getConfig ACmd
-  c        <- traverse resolveMeta mc
+  c        <- traverse (resolveMeta True) mc
   case cmd of
     CheckDB db p       => finally (rmDir tmpDir) $ idrisEnv >>= checkDB p
     FromHEAD p         => env >>= writeLatestDB p

--- a/src/Pack/CmdLn/Opts.idr
+++ b/src/Pack/CmdLn/Opts.idr
@@ -255,6 +255,10 @@ usageInfo = """
       too outdated to build the latest pack. If this fails, try using
       the latest nightly.
 
+    fetch
+      Fetch latest commit hashes from GitHub for packages with a
+      commit entry of "latest:branch".
+
     switch [collection name]
       Switch to the given package collection. This will adjust your
       `$PACK_DIR/.pack/user/pack.toml` file to use the given package

--- a/src/Pack/CmdLn/Types.idr
+++ b/src/Pack/CmdLn/Types.idr
@@ -28,6 +28,7 @@ data Cmd : Type where
   Run              : Either (File Abs) PkgName -> List String -> Cmd
   New              : (cur : CurDir) -> PkgType -> Body -> Cmd
   Update           : Cmd
+  Fetch            : Cmd
 
   -- Idris environment
   PackagePath      : Cmd

--- a/src/Pack/Core/Git.idr
+++ b/src/Pack/Core/Git.idr
@@ -48,10 +48,10 @@ gitCheckout commit = sys "git checkout -q \{commit}"
 export covering
 gitLatest :  HasIO io
           => (url    : URL)
-          -> (commit : Commit)
+          -> (branch : Branch)
           -> EitherT PackErr io Commit
-gitLatest url c =
-  MkCommit . fst . break isSpace <$> sysRun "git ls-remote \{url} \{c}"
+gitLatest url b =
+  MkCommit . fst . break isSpace <$> sysRun "git ls-remote \{url} \{b}"
 
 ||| (Temporary) Directory to use for a Git project.
 export

--- a/src/Pack/Core/Types.idr
+++ b/src/Pack/Core/Types.idr
@@ -215,6 +215,29 @@ Cast Commit (Path Rel) where
   cast = toRelPath . value
 
 --------------------------------------------------------------------------------
+--          Branches
+--------------------------------------------------------------------------------
+
+||| A branch in a git repo.
+public export
+record Branch where
+  constructor MkBranch
+  value : String
+
+export %inline
+Eq Branch where (==) = (==) `on` value
+
+export %inline
+FromString Branch where fromString = MkBranch
+
+export %inline
+Interpolation Branch where interpolate = value
+
+export %inline
+Cast Branch (Path Rel) where
+  cast = toRelPath . value
+
+--------------------------------------------------------------------------------
 --          Package Name
 --------------------------------------------------------------------------------
 

--- a/src/Pack/Database/Types.idr
+++ b/src/Pack/Database/Types.idr
@@ -19,17 +19,20 @@ import Pack.Core.Types
 public export
 data MetaCommit : Type where
   MC     : Commit -> MetaCommit
-  Latest : String -> MetaCommit
+  Latest : Branch -> MetaCommit
+  Fetch  : Branch -> MetaCommit
 
 public export
 FromString MetaCommit where
   fromString s = case forget $ split (':' ==) s of
-    ["latest",branch] => Latest branch
-    _                 => MC $ MkCommit s
+    ["latest",branch]       => Latest $ MkBranch branch
+    ["fetch-latest",branch] => Fetch $ MkBranch branch
+    _                       => MC $ MkCommit s
 
 export
 Interpolation MetaCommit where
   interpolate (Latest b) = "latest:\{b}"
+  interpolate (Fetch b)  = "fetch-latest:\{b}"
   interpolate (MC c)     = "\{c}"
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This is an additional enhancement to #96 , which will cache the latest fetched commit hash, and will only re-fetch commit hashes when invoking `pack fetch`. This will drastically speed up pack's startup time in the presence of custom GitHub packages annotated with `commit = "latest:branch"`. Use `commit = "fetch-latest:branch"` in order to always fetch the latest commit hash when starting pack.