### PR TITLE
Remove docker cache

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,11 +19,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2.4.0
 
-      - name: Cache Docker
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
-
       - name: Get date for DB version
         run: |
           DB_VERSION="nightly-$(date '+%y%m%d')"


### PR DESCRIPTION
Looks like this is failing:
https://github.com/stefan-hoeck/idris2-pack/runs/7777579571?check_suite_focus=true

Also, the action doesn't seem maintained anymore:
https://github.com/satackey/action-docker-layer-caching

Some future work could be to migrate to the official docker build-push-action:
https://github.com/docker/build-push-action

That has some better caching behaviour:
https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md