### PR TITLE
[ fix ] update global pack.toml after switch is completed

### DIFF
--- a/src/Pack/Runner.idr
+++ b/src/Pack/Runner.idr
@@ -146,5 +146,5 @@ runCmd = do
     New dir pty p      => idrisEnv mc fetch >>= new dir pty p
     Switch db          => do
       env <- idrisEnv mc fetch
-      writeCollection
       install []
+      writeCollection


### PR DESCRIPTION
This might be related to #152  . At the very least it is annoying that pack starts using the package collection we are switching to before the switch is completed.