### PR TITLE
[ new ] typecheck and build local packages

### DIFF
--- a/src/Pack/CmdLn/Opts.idr
+++ b/src/Pack/CmdLn/Opts.idr
@@ -194,8 +194,8 @@ usageInfo = """
       consisting of a source directory, default module and a .ipkg file.
       A git repository will be initialized.
 
-    build <.ipkg file>
-      Build a local package given as an `.ipkg` file.
+    build <.ipkg file or local pkg name>
+      Build a local package given as an `.ipkg` file or package name.
 
     exec <.idr file> [args...]
       Compile the given Idris source file and execute its main function
@@ -203,11 +203,12 @@ usageInfo = """
       in the source file's parent directories and will apply the settings
       it finds there.
 
-    install-deps <.ipkg file>
-      Install the dependencies of a local package given as an `.ipkg` file.
+    install-deps <.ipkg file or local pkg name>
+      Install the dependencies of a local package given as an `.ipkg` file
+      or package name.
 
-    typecheck <.ipkg file>
-      Typecheck a local package given as an `.ipkg` file.
+    typecheck <.ipkg file or local pkg name>
+      Typecheck a local package given as an `.ipkg` file or package name.
 
     repl [.idr file]
       Start a REPL session loading an optional `.idr` file.

--- a/src/Pack/CmdLn/Types.idr
+++ b/src/Pack/CmdLn/Types.idr
@@ -16,9 +16,9 @@ data QueryMode = PkgName | Dependency | Module
 public export
 data Cmd : Type where
   -- Developing Idris libs and apps
-  Build            : (ipkg : File Abs) -> Cmd
-  BuildDeps        : (ipkg : File Abs) -> Cmd
-  Typecheck        : (ipkg : File Abs) -> Cmd
+  Build            : Either (File Abs) PkgName -> Cmd
+  BuildDeps        : Either (File Abs) PkgName -> Cmd
+  Typecheck        : Either (File Abs) PkgName -> Cmd
   Repl             : (src : Maybe $ File Abs) -> Cmd
   Exec             : (srd : File Abs) -> (args : List String) -> Cmd
 

--- a/src/Pack/Core/Types.idr
+++ b/src/Pack/Core/Types.idr
@@ -469,6 +469,9 @@ data PackErr : Type where
   ||| The given package is not in the package data base
   UnknownPkg : (name : PkgName) -> PackErr
 
+  ||| The given package is not a local package
+  NotLocalPkg : (name : PkgName) -> PackErr
+
   ||| The given package is not an applicatio
   ||| (No executable name set in the `.ipkg` file)
   NoApp      : (rep : PkgName) -> PackErr
@@ -610,6 +613,8 @@ printErr (InvalidPkgType s) = """
 printErr (InvalidPkgVersion s) = "Invalid package version: \{quote s}."
 
 printErr (UnknownPkg name) = "Unknown package: \{name}"
+
+printErr (NotLocalPkg name) = "Not a local package: \{name}"
 
 printErr (NoApp rep) = "Package \{rep} is not an application"
 

--- a/src/Pack/Runner/Develop.idr
+++ b/src/Pack/Runner/Develop.idr
@@ -99,20 +99,29 @@ exec file args e = do
 
 ||| Build a local library given as an `.ipkg` file.
 export covering %inline
-build : HasIO io => File Abs -> IdrisEnv -> EitherT PackErr io ()
-build f e = parseLibIpkg f f >>= runIdrisOn "--build"
+build :  HasIO io
+      => Either (File Abs) PkgName
+      -> IdrisEnv
+      -> EitherT PackErr io ()
+build f e = findAndParseLocalIpkg f >>= runIdrisOn "--build"
 
 ||| Install dependencies of a local `.ipkg` file
 export covering
-buildDeps : HasIO io => File Abs -> IdrisEnv -> EitherT PackErr io ()
+buildDeps :  HasIO io
+          => Either (File Abs) PkgName
+          -> IdrisEnv
+          -> EitherT PackErr io ()
 buildDeps f e = do
-  d <- parseLibIpkg f f
+  d <- findAndParseLocalIpkg f
   installDeps d
 
 ||| Typecheck a local library given as an `.ipkg` file.
 export covering %inline
-typecheck : HasIO io => File Abs -> IdrisEnv -> EitherT PackErr io ()
-typecheck f e = parseLibIpkg f f >>= runIdrisOn "--typecheck"
+typecheck :  HasIO io
+          => Either (File Abs) PkgName
+          -> IdrisEnv
+          -> EitherT PackErr io ()
+typecheck f e = findAndParseLocalIpkg f >>= runIdrisOn "--typecheck"
 
 ||| Build and execute a local `.ipkg` file.
 export covering
@@ -124,7 +133,7 @@ runIpkg :  HasIO io
 runIpkg p args e = do
   d        <- parseLibIpkg p p
   Just exe <- pure (execPath d) | Nothing => throwE (NoAppIpkg p)
-  build p e
+  build (Left p) e
   sys "\{exe} \{unwords args}"
 
 ||| Install and run an executable given as a package name.


### PR DESCRIPTION
When developing several packages locally in a single project, in can be cumbersome to typecheck a package by giving the path to its `.ipkg` file, as this might be located in a nesting of subfolders. With this PR it is now also possible to specify a local package by its name. Pack will then resolve the package and use the `.ipkg` file listed there for typechecking, building, and installing dependencies.