### PR TITLE
[ doc ] Add a note on possibility of custom build hooks prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ run
 pack install-app katla
 ```
 
+> **Note**
+>
+> Idris packages can contain additional instructions to run before and after build and installation of a package,
+> we call them *custom build hooks*.
+> This can be potentially dangerous because hooks may invoke arbitrary code in your system.
+> By default pack prompts for continuation in case when requested package contains them, e.g.
+>
+> ```sh
+> Package lsp uses custom build hooks. Continue (yes/*no)?
+> ```
+
 If you no longer require *katla* and want to remove it, run
 
 ```sh


### PR DESCRIPTION
User experience story: I decided to try `pack` (and this is great tool, I must say), I read readme and the first thing I decided to install was `lsp`. But immediately I got a prompt asking something not familiar to me -- something about custom build hooks. That was disappointing.

I think mentioning of them worth to be in the readme. At least this prompt would not be a complete surprise. I suggest some wording for this.