### PR TITLE
[ minor, ux ] Make info message to be one line

### DIFF
--- a/src/Pack/Runner/Install.idr
+++ b/src/Pack/Runner/Install.idr
@@ -316,10 +316,7 @@ update e =
       ipkg := MkF dir "pack.ipkg"
       bin  := packBinDir
    in finally (rmDir dir) $ do
-        info """
-          Updating pack. If this fails, try switching to the latest
-          package collection.
-          """
+        info "Updating pack. If this fails, try switching to the latest package collection."
         gitClone packRepo dir
         traverse_ (\c => inDir dir $ \_ => gitCheckout c) packCommit
 


### PR DESCRIPTION
Please, forgive me if it was intended, but I think, the current look with "package collection" on another line looks weird, especially near with the rest of output which takes much longer than this particular line. WDYT?

![p](https://user-images.githubusercontent.com/2602116/192033024-7113a626-d331-427e-b19c-b98d6f38bd6d.png)

I also want to suggest general treatment of newlines in log messages to make all look (subjectively?) better.