### PR TITLE
[ minor, fix ] Add forgotten module to the `pack.ipkg`

### DIFF
--- a/pack.ipkg
+++ b/pack.ipkg
@@ -44,6 +44,7 @@ modules = Pack.CmdLn
         , Pack.Runner.Database
         , Pack.Runner.Develop
         , Pack.Runner.Install
+        , Pack.Runner.New
         , Pack.Runner.Query
 
         , Pack.Version


### PR DESCRIPTION
I've found it when was playing with cleaning. By the way, I found out that `pack-admin.ipkg` and `micropack.ipkg` do not have modules list at all, thus for these packages only their main module is cleaned.