### PR TITLE
[ logging ] Print all lines of the log message indented

### DIFF
--- a/src/Pack/Config/Environment.idr
+++ b/src/Pack/Config/Environment.idr
@@ -355,9 +355,30 @@ idrisWithPkgs pkgs =
 --          Logging
 --------------------------------------------------------------------------------
 
+printLogMessage :  HasIO io
+                => (lvl : LogLevel)
+                -> (msg : String)
+                -> (msgs : List String)
+                -> io ()
+printLogMessage lvl msg msgs = do
+  let prefx = "[ \{lvl} ] "
+  let baseIndent = replicate (length prefx) ' '
+  printMultilineIndented prefx baseIndent msg
+  for_ msgs $ printMultilineIndented "\{baseIndent}- " "\{baseIndent}  "
+
+  where
+    printMultilineIndented :  (fstPrefix, restPrefix : String)
+                           -> (msg : String)
+                           -> io ()
+    printMultilineIndented fstPrefix restPrefix msg = do
+      let (s::ss) = lines msg
+        | [] => putStrLn "\{fstPrefix}"
+      putStrLn "\{fstPrefix}\{s}"
+      for_ ss $ \s => putStrLn "\{restPrefix}\{s}"
+
 ||| Logs a message to stdout if the log level is greater than or equal
 ||| than the reference level `ref`.
-||| If the given string contains newlines, all lines are printed idented
+||| If the given string contains newlines, all lines are printed indented
 ||| to the beginning of the first one.
 export
 log :  HasIO io
@@ -366,17 +387,11 @@ log :  HasIO io
     -> (msg : Lazy String)
     -> io ()
 log ref lvl msg =
-  when (lvl >= ref) $ do
-    let (s::ss) = lines msg
-      | [] => pure ()
-    let prefx = "[ \{lvl} ] "
-    putStrLn "\{prefx}\{s}"
-    when (not $ null ss) $ do
-      let prefx = replicate (length prefx) ' '
-      for_ ss $ \s => putStrLn "\{prefx}\{s}"
+  when (lvl >= ref) $ printLogMessage lvl msg []
 
 ||| Logs an idented list of values to stdout if the given log level
 ||| is greater than or equal than the (auto-implicit) reference level `ref`.
+||| If messages list is empty, no log message is printed.
 |||
 ||| Note: Most of the time `ref` is automatically being extracted from
 ||| a value of type `Pack.Config.Types.Config` in scope.
@@ -388,8 +403,7 @@ logMany :  HasIO io
         -> (msgs : Lazy (List String))
         -> io ()
 logMany lvl msg msgs =
-  when (lvl >= ref && not (null msgs)) $ do
-    log ref lvl $ unlines (msg :: map (indent 2) msgs)
+  when (lvl >= ref && not (null msgs)) $ printLogMessage lvl msg msgs
 
 ||| Alias for `log ref Debug`.
 |||

--- a/src/Pack/Config/Environment.idr
+++ b/src/Pack/Config/Environment.idr
@@ -2,6 +2,7 @@ module Pack.Config.Environment
 
 import Data.Maybe
 import Data.SortedMap as SM
+import Data.String
 import Idris.Package.Types
 import Pack.CmdLn
 import Pack.Config.TOML
@@ -356,6 +357,8 @@ idrisWithPkgs pkgs =
 
 ||| Logs a message to stdout if the log level is greater than or equal
 ||| than the reference level `ref`.
+||| If the given string contains newlines, all lines are printed idented
+||| to the beginning of the first one.
 export
 log :  HasIO io
     => (ref : LogLevel)
@@ -363,7 +366,14 @@ log :  HasIO io
     -> (msg : Lazy String)
     -> io ()
 log ref lvl msg =
-  when (lvl >= ref) (putStrLn "[ \{lvl} ] \{msg}")
+  when (lvl >= ref) $ do
+    let (s::ss) = lines msg
+      | [] => pure ()
+    let prefx = "[ \{lvl} ] "
+    putStrLn "\{prefx}\{s}"
+    when (not $ null ss) $ do
+      let prefx = replicate (length prefx) ' '
+      for_ ss $ \s => putStrLn "\{prefx}\{s}"
 
 ||| Logs an idented list of values to stdout if the given log level
 ||| is greater than or equal than the (auto-implicit) reference level `ref`.


### PR DESCRIPTION
Manages the case when string of the log message contains newlines. I personally think that when the whole log message is indented uniformly, this reads better.

Notice that this PR changes a bit present behaviour, especially of `logMany`. Previously, say, "installing libraries" message was looking like this:

```
...
[ info ] Installing libraries:
  toml
  filepath
[ info ] Installing library (with sources): toml
...
```

This change makes this look like this:

```
...
[ info ] Installing libraries:
           toml
           filepath
[ info ] Installing library (with sources): toml
...
```

One more change is that `log` for an empty string now does nothing and before is would print the log prefix. I can revert this behaviour, but I thought that if `logMany` does nothing if it has non-empty message and empty list of next lines, it would be somewhat consistent if `log` would do nothing for an empty string.

Also, this is not optimal since `logMany` forms a string using `unlines` which then again is treated with `lines`. It could be implemented vice-versa, `log` through `logMany`, but then `logMany` should be changed to log message even for empty list of additional lines but anyway, those lines should again be treated with `lines` in case they contain newlines. I left it this way mostly because of simplicity and for minimal change, but I can go fancy and try to do all in less elegant but more effective way. One additional plus of this approach would be that now if you do `logMany Info "foo" ["bar\nbaz"]`, now it prints like

```
[ info ] foo
           bar
         baz
```

but we could treat `baz` to be indented as `bar` in this fancy implementation.

UPD: By the way, in the fancy implementation we could even print the case above as

```
[ info ] foo
         - bar
           baz
```
