### PR TITLE
[ refactor ] Make log levels list to have a single source of truth

### DIFF
--- a/src/Pack/CmdLn/Completion.idr
+++ b/src/Pack/CmdLn/Completion.idr
@@ -92,9 +92,6 @@ codegens =
   , "vmcode-interp"
   ]
 
-logLevels : List String
-logLevels = [ "debug", "build", "info", "warning", "silence" ]
-
 optionFlags : List String
 optionFlags =
   [ "app-path"
@@ -143,7 +140,7 @@ opts x "-p"               = prefixOnlyIfNonEmpty x <$> collections
 opts x "-P"               = prefixOnlyIfNonEmpty x <$> pure packages
 opts x "--packages"       = prefixOnlyIfNonEmpty x <$> pure packages
 opts x "--cg"             = prefixOnlyIfNonEmpty x <$> pure codegens
-opts x "--log-level"      = prefixOnlyIfNonEmpty x <$> pure logLevels
+opts x "--log-level"      = prefixOnlyIfNonEmpty x <$> pure (fst <$> logLevels)
 
 -- actions
 opts x "app-path"         = prefixOnlyIfNonEmpty x <$> installedApps
@@ -159,7 +156,7 @@ opts x "install"          = prefixOnlyIfNonEmpty x <$> pure packages
 opts x "install-app"      = prefixOnlyIfNonEmpty x <$> apps
 opts x "remove"           = prefixOnlyIfNonEmpty x <$> installedLibs
 opts x "remove-app"       = prefixOnlyIfNonEmpty x <$> installedApps
-opts x "switch"           =   prefixOnlyIfNonEmpty x . ("latest" ::)
+opts x "switch"           = prefixOnlyIfNonEmpty x . ("latest" ::)
                             <$> collections
 opts x "clean"            = prefixOnlyIfNonEmpty x <$> ipkgFiles
 opts x "typecheck"        = prefixOnlyIfNonEmpty x <$> ipkgFiles

--- a/src/Pack/CmdLn/Opts.idr
+++ b/src/Pack/CmdLn/Opts.idr
@@ -145,7 +145,7 @@ descs = [ MkOpt ['p'] ["package-set"]   (ReqArg setDB "<db>")
         , MkOpt [] ["log-level"]   (ReqArg loglevel "<log level>")
             """
             Specify the logging level to use. Accepted values are:
-            "debug", "build", "info", "warning", and "silence".
+            \{joinBy ", " $ show . fst <$> logLevels}.
             """
         ]
 

--- a/src/Pack/Core/Types.idr
+++ b/src/Pack/Core/Types.idr
@@ -537,6 +537,51 @@ record LineBufferingCmd where
   lineBufferingCmd : CmdArgList
 
 --------------------------------------------------------------------------------
+--          Logging
+--------------------------------------------------------------------------------
+
+||| Level used during logging.
+public export
+data LogLevel : Type where
+  [noHints]
+  Debug   : LogLevel
+  Build   : LogLevel
+  Info    : LogLevel
+  Warning : LogLevel
+  Silence : LogLevel
+
+llToNat : LogLevel -> Nat
+llToNat Debug   = 0
+llToNat Build   = 1
+llToNat Info    = 2
+llToNat Warning = 3
+llToNat Silence = 4
+
+export
+Eq LogLevel where (==) = (==) `on` llToNat
+
+export
+Ord LogLevel where compare = compare `on` llToNat
+
+export
+Interpolation LogLevel where
+  interpolate Debug   = "debug"
+  interpolate Build   = "build"
+  interpolate Info    = "info"
+  interpolate Warning = "warning"
+  interpolate Silence = ""
+
+export
+logLevels : List (String, LogLevel)
+logLevels =
+  [ ("debug"  , Debug  )
+  , ("build"  , Build  )
+  , ("info"   , Info   )
+  , ("warning", Warning)
+  , ("silence", Silence)
+  ]
+
+--------------------------------------------------------------------------------
 --          Errors
 --------------------------------------------------------------------------------
 
@@ -835,51 +880,6 @@ readAbsFile : (curdir : Path Abs) -> String -> Either PackErr (File Abs)
 readAbsFile cd s = case split $ toAbsPath cd (fromString s) of
   Just (p,b) => Right $ MkF p b
   Nothing    => Left (NoFilePath s)
-
---------------------------------------------------------------------------------
---          Logging
---------------------------------------------------------------------------------
-
-||| Level used during logging.
-public export
-data LogLevel : Type where
-  [noHints]
-  Debug   : LogLevel
-  Build   : LogLevel
-  Info    : LogLevel
-  Warning : LogLevel
-  Silence : LogLevel
-
-llToNat : LogLevel -> Nat
-llToNat Debug   = 0
-llToNat Build   = 1
-llToNat Info    = 2
-llToNat Warning = 3
-llToNat Silence = 4
-
-export
-Eq LogLevel where (==) = (==) `on` llToNat
-
-export
-Ord LogLevel where compare = compare `on` llToNat
-
-export
-Interpolation LogLevel where
-  interpolate Debug   = "debug"
-  interpolate Build   = "build"
-  interpolate Info    = "info"
-  interpolate Warning = "warning"
-  interpolate Silence = ""
-
-export
-logLevels : List (String, LogLevel)
-logLevels =
-  [ ("debug"  , Debug  )
-  , ("build"  , Build  )
-  , ("info"   , Info   )
-  , ("warning", Warning)
-  , ("silence", Silence)
-  ]
 
 export
 readLogLevel : String -> Either PackErr LogLevel

--- a/src/Pack/Core/Types.idr
+++ b/src/Pack/Core/Types.idr
@@ -5,6 +5,7 @@
 module Pack.Core.Types
 
 import public Data.FilePath.File
+import Data.Either
 import Data.Maybe
 import Idris.Package.Types
 import System.File
@@ -745,11 +746,7 @@ printErr (InvalidPkgVersion s) = "Invalid package version: \{quote s}."
 
 printErr (InvalidLogLevel s) = """
   Invalid log level: \{quote s}. Valid values are
-    debug
-    build
-    info
-    warning
-    silence
+  \{joinBy "\n" $ ("- " ++) . fst <$> logLevels}
   """
 
 printErr (UnknownPkg name) = "Unknown package: \{name}"
@@ -875,10 +872,15 @@ Interpolation LogLevel where
   interpolate Silence = ""
 
 export
+logLevels : List (String, LogLevel)
+logLevels =
+  [ ("debug"  , Debug  )
+  , ("build"  , Build  )
+  , ("info"   , Info   )
+  , ("warning", Warning)
+  , ("silence", Silence)
+  ]
+
+export
 readLogLevel : String -> Either PackErr LogLevel
-readLogLevel "debug"   = Right Debug
-readLogLevel "build"   = Right Build
-readLogLevel "info"    = Right Info
-readLogLevel "warning" = Right Warning
-readLogLevel "silence" = Right Silence
-readLogLevel str       = Left (InvalidLogLevel str)
+readLogLevel str = maybeToEither (InvalidLogLevel str) $ lookup str logLevels


### PR DESCRIPTION
Basically, remove code duplication, mainly from help and error messages. This change is split to two commits to ease review, since the second commit it purely technical.

UPD: Oh, I forgot to say, that this PR slightly changes help and error messages: in help message `"and"` is replaced with `", "` for simplicity, and error message for wrong log level was changed to contain `"- "` before each alternative.