### PR TITLE
[ new ] Support for passing additional arguments to `rlwrap`

### DIFF
--- a/src/Pack/CmdLn/Opts.idr
+++ b/src/Pack/CmdLn/Opts.idr
@@ -47,8 +47,8 @@ setPrompt b _ = Right . {safetyPrompt := b}
 setScheme : String -> AdjConf
 setScheme s _ = Right . {scheme := fromString s}
 
-setRlwrap : Bool -> AdjConf
-setRlwrap b _ = Right . {rlwrap := b }
+setRlwrap : Maybe String -> AdjConf
+setRlwrap args _ = Right . {rlwrap := UseRlwrap $ maybe [] (\s => [NoEscape s]) args}
 
 setIpkg : String -> AdjConf
 setIpkg v (CD dir) c = case readAbsFile dir v of
@@ -136,7 +136,7 @@ descs = [ MkOpt ['p'] ["package-set"]   (ReqArg setDB "<db>")
             """
             Don't look for an `.ipkg` file in scope when starting a REPL session.
             """
-        , MkOpt [] ["rlwrap"]   (NoArg $ setRlwrap True)
+        , MkOpt [] ["rlwrap"]   (OptArg setRlwrap "<rlwrap args>")
             "Run a REPL session in `rlwrap`."
         , MkOpt ['v'] ["verbose"]   (NoArg debug)
             "Print debugging information"

--- a/src/Pack/Config/TOML.idr
+++ b/src/Pack/Config/TOML.idr
@@ -22,6 +22,15 @@ FromTOML Codegen where
   fromTOML = tmap Types.fromString
 
 export
+FromTOML RlwrapConfig where
+  fromTOML _ (VBoolean x)  = Right $ if x then UseRlwrap [] else DoNotUseRlwrap
+  fromTOML _ (VString str) = Right $ UseRlwrap [NoEscape str]
+  fromTOML _ (VArray xs)   = map (UseRlwrap . fromStrList) $ for xs $ \case
+                               VString s => Right s
+                               _         => Left $ WrongType [] "array of strings"
+  fromTOML _ _             = Left $ WrongType [] "boolean, string or array of strings"
+
+export
 FromTOML UserConfig where
   fromTOML f v =
       [| MkConfig (maybeValAt "collection" f v)
@@ -113,6 +122,9 @@ initToml scheme db = """
   # Set this to `true` in order to run REPL sessions from within
   # `rlwrap`. This will give you additional features such as a
   # command history.
+  # Alternatively, you can pass additional command-line arguments
+  # to `rlwrap` by setting this to a string or an array of strings,
+  # e.g. to "-pGreen -aN" or ["-pGreen", "--no-children"].
   repl.rlwrap = false
 
   # Packages to load automatically when starting a REPL session

--- a/src/Pack/Config/Types.idr
+++ b/src/Pack/Config/Types.idr
@@ -114,6 +114,17 @@ data WithIpkg : Type where
   ||| argument.
   Use    : (ipkg : File Abs) -> WithIpkg
 
+||| Data type describing whether `rlwrap` command should be used
+||| and which additional arguments should be passed to it.
+|||
+||| This is basically equivalent to `Maybe CmdArgList`, but
+||| separate type disallows confusion with `Maybe` from `MConfig`,
+||| i.e. between not being set and set to not to use `rlwrap`.
+public export
+data RlwrapConfig : Type where
+  DoNotUseRlwrap : RlwrapConfig
+  UseRlwrap      : CmdArgList -> RlwrapConfig
+
 ||| Type-level identity
 public export
 0 I : Type -> Type
@@ -178,7 +189,7 @@ record Config_ (f : Type -> Type) (c : Type) where
   withIpkg     : f WithIpkg
 
   ||| Whether to use `rlwrap` to run a REPL session
-  rlwrap       : f Bool
+  rlwrap       : f RlwrapConfig
 
   ||| Libraries to install automatically
   autoLibs     : f (List PkgName)
@@ -300,7 +311,7 @@ init coll = MkConfig {
   , withDocs     = False
   , useKatla     = False
   , withIpkg     = Search cur
-  , rlwrap       = False
+  , rlwrap       = DoNotUseRlwrap
   , autoLibs     = []
   , autoApps     = []
   , autoLoad     = NoPkgs

--- a/src/Pack/Runner/Develop.idr
+++ b/src/Pack/Runner/Develop.idr
@@ -90,8 +90,8 @@ idrisRepl mf e = do
       exe := idrisWithCG
 
   cmd <- case e.env.config.rlwrap of
-    True  => pure $ ["rlwrap"] ++ exe ++ opts ++ arg
-    False => pure $ exe ++ opts ++ arg
+    UseRlwrap rargs => pure $ ["rlwrap"] ++ rargs ++ exe ++ opts ++ arg
+    DoNotUseRlwrap  => pure $ exe ++ opts ++ arg
 
   case mp of
     Just af => inDir af.parent $ \_ => sysWithEnv cmd [pth]


### PR DESCRIPTION
Closes #189.

Well, as I said in the original issue, I've implemented a solution where existing `repl.rlwrap` option can be not only a boolean, but take also a string or array of strings with additional arguments.

But only after implementation I thought that *maybe* having a separate option would be good for the case when `--rlwrap` option is given. It could turn on usage of `rlwrap` itself, while taking additional arguments from the `pack.toml`. However, I personally, don't feel this case realistic, since I think either one uses `rlwrap` (and maybe tunes it), or just does not use. What do you think?

For now, `--rlwrap` CLI option takes an optional string with additional arguments, just in case.