### PR TITLE
[ refactor ] command help and clearer errors

### DIFF
--- a/src/Pack/CmdLn/Completion.idr
+++ b/src/Pack/CmdLn/Completion.idr
@@ -92,35 +92,11 @@ codegens =
   , "vmcode-interp"
   ]
 
+commands : List String
+commands = map fst namesAndCommands
+
 optionFlags : List String
-optionFlags =
-  [ "app-path"
-  , "build"
-  , "clean"
-  , "completion"
-  , "completion-script"
-  , "data-path"
-  , "exec"
-  , "fetch"
-  , "fuzzy"
-  , "help"
-  , "info"
-  , "install"
-  , "install-app"
-  , "install-deps"
-  , "libs-path"
-  , "new"
-  , "package-path"
-  , "query"
-  , "remove"
-  , "remove-app"
-  , "repl"
-  , "run"
-  , "switch"
-  , "typecheck"
-  , "update-db"
-  , "update"
-  ] ++ optionNames
+optionFlags = commands ++ optionNames
 
 queries : Env => List String
 queries = ["dep", "module"] ++ packages
@@ -160,7 +136,8 @@ opts x "switch"           = prefixOnlyIfNonEmpty x . ("latest" ::)
                             <$> collections
 opts x "clean"            = prefixOnlyIfNonEmpty x <$> ipkgFiles
 opts x "typecheck"        = prefixOnlyIfNonEmpty x <$> ipkgFiles
-opts x "new"              = prefixOnlyIfNonEmpty x <$> pure (packageTypes)
+opts x "new"              = prefixOnlyIfNonEmpty x <$> pure packageTypes
+opts x "help"             = prefixOnlyIfNonEmpty x <$> pure commands
 
 -- options
 opts x _ = pure $ if (x `elem` optionFlags)

--- a/src/Pack/CmdLn/Opts.idr
+++ b/src/Pack/CmdLn/Opts.idr
@@ -203,6 +203,8 @@ usageInfo = """
   Options:
   \{usageInfo "" descs}
 
+  Run `pack help <cmd>` to get detailed information about a command.
+
   Available commands:
   \{unlines $ map (indent 2 . fst) namesAndCommands}
   """

--- a/src/Pack/CmdLn/Types.idr
+++ b/src/Pack/CmdLn/Types.idr
@@ -89,6 +89,9 @@ data Cmd : Type where
   -- Help
   PrintHelp        : Cmd
 
+||| List of all available commands.
+|||
+||| `Pack.CmdLn.Types.cmdInCommands` proofs that none was forgotten.
 public export
 commands : List Cmd
 commands =
@@ -155,6 +158,7 @@ public export
 namesAndCommands : List (String,Cmd)
 namesAndCommands = map (\c => (name c, c)) commands
 
+||| Usage info for each command. This is printed when invoking `pack help <cmd>`.
 export
 cmdDesc : Cmd -> String
 cmdDesc Build            = """

--- a/src/Pack/CmdLn/Types.idr
+++ b/src/Pack/CmdLn/Types.idr
@@ -1,6 +1,8 @@
 module Pack.CmdLn.Types
 
-import Pack.Core.Types
+import Data.List.Elem
+import Pack.Core
+import Pack.Config.Types
 import Pack.Database.Types
 
 %default total
@@ -10,24 +12,58 @@ import Pack.Database.Types
 public export
 data QueryMode = PkgName | Dependency | Module
 
+||| A query to be run against the package collection
+public export
+record PkgQuery where
+  constructor MkQ
+  mode  : QueryMode
+  query : String
+
+export
+Arg PkgQuery where
+  argDesc_ = "dep <query> | module <query> | <query"
+
+  readArg ("dep" :: s :: t)     = Just (MkQ Dependency s, t)
+  readArg ("modules" :: s :: t) = Just (MkQ Module s, t)
+  readArg [s]                   = Just (MkQ PkgName s, [])
+  readArg _                     = Nothing
+
+public export
+record FuzzyQuery where
+  constructor MkFQ
+  pkgs  : List PkgName
+  query : String
+
+export
+Arg FuzzyQuery where
+  argDesc_ = "[<pkgs>] <query>"
+
+  readArg (ps :: s :: t) =
+    let pkgs = map MkPkgName $ forget $ split (',' ==) ps
+     in Just (MkFQ pkgs s, t)
+  readArg [s] = Just (MkFQ [] s, [])
+  readArg []  = Nothing
+
 ||| Commands accepted by *pack*. Most of these
 ||| operate on a list of packages and/or
 ||| projects with an `.ipkg` file.
 public export
 data Cmd : Type where
   -- Developing Idris libs and apps
-  Build            : Either (File Abs) PkgName -> Cmd
-  BuildDeps        : Either (File Abs) PkgName -> Cmd
-  Typecheck        : Either (File Abs) PkgName -> Cmd
-  Clean            : Either (File Abs) PkgName -> Cmd
-  Repl             : (src : Maybe $ File Abs) -> Cmd
-  Exec             : (srd : File Abs) -> (args : CmdArgList) -> Cmd
+  Build            : Cmd
+  BuildDeps        : Cmd
+  Typecheck        : Cmd
+  Clean            : Cmd
+  Repl             : Cmd
+  Exec             : Cmd
 
   -- Package management
-  Install          : List (InstallType,PkgName) -> Cmd
-  Remove           : List (PkgType,PkgName) -> Cmd
-  Run              : Either (File Abs) PkgName -> CmdArgList -> Cmd
-  New              : (cur : CurDir) -> PkgType -> Body -> Cmd
+  Install          : Cmd
+  InstallApp       : Cmd
+  Remove           : Cmd
+  RemoveApp        : Cmd
+  Run              : Cmd
+  New              : Cmd
   Update           : Cmd
   Fetch            : Cmd
 
@@ -35,20 +71,325 @@ data Cmd : Type where
   PackagePath      : Cmd
   LibsPath         : Cmd
   DataPath         : Cmd
-  AppPath          : PkgName -> Cmd
+  AppPath          : Cmd
 
   -- Managing package collections
-  Switch           : DBName -> Cmd
+  Switch           : Cmd
   UpdateDB         : Cmd
 
   -- Queries
   Info             : Cmd
-  Query            : QueryMode -> String -> Cmd
-  Fuzzy            : List PkgName -> String -> Cmd
+  Query            : Cmd
+  Fuzzy            : Cmd
 
   -- Tab completion
-  Completion       : String -> String -> Cmd
-  CompletionScript : String -> Cmd
+  Completion       : Cmd
+  CompletionScript : Cmd
 
   -- Help
   PrintHelp        : Cmd
+
+public export
+commands : List Cmd
+commands =
+  [ Build
+  , BuildDeps
+  , Typecheck
+  , Clean
+  , Repl
+  , Exec
+  , Install
+  , InstallApp
+  , Remove
+  , RemoveApp
+  , Run
+  , New
+  , Update
+  , Fetch
+  , PackagePath
+  , LibsPath
+  , DataPath
+  , AppPath
+  , Switch
+  , UpdateDB
+  , Info
+  , Query
+  , Fuzzy
+  , Completion
+  , CompletionScript
+  , PrintHelp
+  ]
+
+||| Name to use at the command-line for running a pack command
+public export
+name : Cmd -> String
+name Build            = "build"
+name BuildDeps        = "install-deps"
+name Typecheck        = "typecheck"
+name Clean            = "clean"
+name Repl             = "repl"
+name Exec             = "exec"
+name Install          = "install"
+name InstallApp       = "install-app"
+name Remove           = "remove"
+name RemoveApp        = "remove-app"
+name Run              = "run"
+name New              = "new"
+name Update           = "update"
+name Fetch            = "fetch"
+name PackagePath      = "package-path"
+name LibsPath         = "libs-path"
+name DataPath         = "data-path"
+name AppPath          = "app-path"
+name Switch           = "switch"
+name UpdateDB         = "update-db"
+name Info             = "info"
+name Query            = "query"
+name Fuzzy            = "fuzzy"
+name Completion       = "completion"
+name CompletionScript = "completion-script"
+name PrintHelp        = "help"
+
+||| List pairing a command with its name used for parsing commands.
+public export
+namesAndCommands : List (String,Cmd)
+namesAndCommands = map (\c => (name c, c)) commands
+
+export
+cmdDesc : Cmd -> String
+cmdDesc Build            = """
+  Build a local package given as an `.ipkg` file or package name.
+  This will also install the package's dependencies.
+  """
+
+cmdDesc BuildDeps        = """
+  Install the dependencies of a local package given as an `.ipkg` file
+  or package name.
+  """
+
+cmdDesc Typecheck        = """
+  Typecheck a local package given as an `.ipkg` file or package name.
+  """
+
+cmdDesc Clean            = """
+  Clean up a local package by invoking `idris2 --clean` on its
+  `.ipkg` file
+  """
+
+cmdDesc Repl             = """
+  Start a REPL session loading an optional `.idr` file.
+  Use command line option `--with-ipkg` to load settings
+  and packages from an `.ipkg` file. Option `--no-ipkg` can be used
+  to not go looking for an `.ipkg` file. The default behavior
+  is for pack to use the first `.ipkg` file it can find in the
+  current directory or one of its parent directories.
+
+  In order to start the REPL session with the `rlwrap` utility, use
+  the `--rlwrap` command-line option or set flag `repl.rlwrap` in one
+  of your `pack.toml` files either to `true` or to a string containing
+  additional arguments to be used when running `rlwrap`.
+  """
+
+cmdDesc Exec             = """
+  Compile the given Idris source file and execute its main function
+  with the given list of arguments. This will look for `.ipkg` files
+  in the source file's parent directories and will apply the settings
+  it finds there.
+
+  To change the name of the generated executable, use the `-o` command-line
+  option.
+
+  To change the codegen to use, use the `--cg` command-line option.
+  """
+
+cmdDesc Install          = "Install the given packages."
+
+cmdDesc InstallApp       = "Install the given applications."
+
+cmdDesc Remove           = "Uninstall the given libraries."
+
+cmdDesc RemoveApp        = "Uninstall the given applications."
+
+cmdDesc Run              = """
+  Run an application from the package collection or a local `.ipkg`
+  file passing it the given command line arguments.
+
+  Note: This will install remote apps before running them without
+  generating an entry in `$PACK_DIR/bin`.
+  Local apps and applications specified as mere `.ipkg` files
+  will be built and run locally without installing them.
+
+  To change the codegen to use, use the `--cg` command-line option.
+  """
+
+cmdDesc New              = """
+  Create a new package in the current directory
+  consisting of a source directory, default module and a .ipkg file.
+  A git repository will also be initialized together with a
+  suitable `.gitignore` file.
+
+  Note: Since module names with a hyphen ('-') are not supported by
+  Idris, any hyphen in the package name will be replaced with an
+  underscore ('_') in the generated module name.
+  """
+
+cmdDesc Update           = """
+  Update the pack installation by downloading and building
+  the current main branch of
+  https://github.com/stefan-hoeck/idris2-pack.
+
+  In order to specify a different commit or repository to use, adjust
+  settings `pack.url` and `pack.commit` in one of your `pack.toml`
+  files.
+
+  Note: This uses the current package collection, which might be
+  too outdated to build the latest pack. If this fails, try using
+  the latest nightly.
+  """
+
+cmdDesc Fetch            = """
+  Fetch the latest commit hashes from GitHub for remote packages with a
+  commit entry of "latest:branch".
+  """
+
+cmdDesc PackagePath      = """
+  Return a colon-separated list of paths where Idris packages are
+  installed. This is useful for programs like `idris2-lsp`,
+  which need to know where to look for installed packages.
+  """
+
+cmdDesc LibsPath         = """
+  Return a colon-separated list of paths where libraries
+  for code generation are installed.
+  """
+
+cmdDesc DataPath         = """
+  Return a colon-separated list of paths where data files
+  are installed.
+  """
+
+cmdDesc AppPath          = """
+  Return the absolute path to the given application managed by pack.
+  `pack app-path idris2` returns the path to the current Idris compiler
+  """
+
+cmdDesc Switch           = """
+  Switch to the given package collection. This will adjust your
+  `$PACK_DIR/user/pack.toml` file to use the given package
+  collection. It will also install all auto libs and apps from the
+  given package collection.
+
+  Note: It is also possible to switch to the latest package
+  collection by using "latest" as the collection name.
+  """
+
+cmdDesc UpdateDB         = """
+  Update the pack data base by downloading the package collections
+  from https://github.com/stefan-hoeck/idris2-pack-db.
+  """
+
+cmdDesc Info             = """
+  Print general information about the current package
+  collection and list installed applications and libraries.
+  """
+
+cmdDesc Query            = """
+  Query the package collection for the given name.
+  Several command line options exist to specify the type
+  of information printed. The optional mode argument
+  defines the type of query to use:
+
+    * `dep`    : Search a package by its dependencies. For
+      instance, `pack query dep sop` will list all packages,
+      which have a dependency on the sop library. Only exact
+      matches will be listed.
+
+    * `module` : Search a package by its modules. For
+      instance, `pack query module Data.List` will list all packages,
+      which export module `Data.List`. Only exact matches will
+      be listed.
+
+    * none     : List packages whose names have the query
+      string as a substring.
+
+  The following command-line options affect the kind of information displayed
+  for each found package:
+
+    -d --dependencies : Prints the dependencies of each query result
+    -s --short-desc   : Prints the `brief` description from each package's
+                        `.ipkg` file.
+    -l --long-desc    : Prints detailed description of each query result
+  """
+
+cmdDesc Fuzzy            = """
+  Run a fuzzy search by type over a comma-separated list of packages.
+  If no packages are given, all installed packages will be queried
+  (which might take several minutes).
+
+  Example: fuzzy base "HasIO -> Bool", will find functions taking
+  an argument of type `HasIO` and returning a boolean result in the
+  *base* library.
+  """
+
+cmdDesc Completion       = """
+  Returns a list of possible completion strings for the given arguments.
+  This is invoked by the shell script returned by `pack \{name CompletionScript}`.
+  See the installation instructions about how to enable TAB-completion
+  for your shell.
+  """
+
+cmdDesc CompletionScript = """
+  Prints a shell script, which can be used for BASH-like TAB-completion.
+  See the installation instructions about how to enable TAB-completion
+  for your shell.
+  """
+
+cmdDesc PrintHelp        = """
+  Without an additional <cmd> argument, this prints general information
+  about using pack, including a list of available command-line options
+  and a description of what each of them does.
+
+  If an explicit command is given, this gives some detail about what
+  the command in question does and what additional arguments it takes.
+
+  Available commands:
+  \{unlines $ map (indent 2 . fst) namesAndCommands}
+  """
+
+export
+Arg Cmd where
+  argDesc_ = "[ cmd ]"
+
+  readArg = parseSingleMaybe (`lookup` namesAndCommands)
+
+--------------------------------------------------------------------------------
+--          Proofs
+--------------------------------------------------------------------------------
+
+0 cmdInCommands : (c : Cmd) -> Elem c Types.commands
+cmdInCommands Build            = %search
+cmdInCommands BuildDeps        = %search
+cmdInCommands Typecheck        = %search
+cmdInCommands Clean            = %search
+cmdInCommands Repl             = %search
+cmdInCommands Exec             = %search
+cmdInCommands Install          = %search
+cmdInCommands InstallApp       = %search
+cmdInCommands Remove           = %search
+cmdInCommands RemoveApp        = %search
+cmdInCommands Run              = %search
+cmdInCommands New              = %search
+cmdInCommands Update           = %search
+cmdInCommands Fetch            = %search
+cmdInCommands PackagePath      = %search
+cmdInCommands LibsPath         = %search
+cmdInCommands DataPath         = %search
+cmdInCommands AppPath          = %search
+cmdInCommands Switch           = %search
+cmdInCommands UpdateDB         = %search
+cmdInCommands Info             = %search
+cmdInCommands Query            = %search
+cmdInCommands Fuzzy            = %search
+cmdInCommands Completion       = %search
+cmdInCommands CompletionScript = %search
+cmdInCommands PrintHelp        = %search

--- a/src/Pack/CmdLn/Types.idr
+++ b/src/Pack/CmdLn/Types.idr
@@ -21,7 +21,7 @@ record PkgQuery where
 
 export
 Arg PkgQuery where
-  argDesc_ = "dep <query> | module <query> | <query"
+  argDesc_ = "[mode] <query>"
 
   readArg ("dep" :: s :: t)     = Just (MkQ Dependency s, t)
   readArg ("modules" :: s :: t) = Just (MkQ Module s, t)
@@ -358,7 +358,7 @@ cmdDesc PrintHelp        = """
 
 export
 Arg Cmd where
-  argDesc_ = "[ cmd ]"
+  argDesc_ = "<cmd>"
 
   readArg = parseSingleMaybe (`lookup` namesAndCommands)
 

--- a/src/Pack/Config/Environment.idr
+++ b/src/Pack/Config/Environment.idr
@@ -421,7 +421,7 @@ getConfig :  (0 c : Type)
           => (pd        : PackDir)
           => (td        : TmpDir)
           => (cur       : CurDir)
-          => EitherT PackErr io (MetaConfig,c)
+          => EitherT PackErr io (MetaConfig, CommandWithArgs c)
 getConfig c = do
   -- relevant directories
   coll       <- defaultColl
@@ -436,7 +436,12 @@ getConfig c = do
 
   let ini = foldl update (init coll `update` global) localConfs
 
-  pn :: args  <- getArgs | Nil => pure (ini, defaultCommand c)
+  args'       <- getArgs
+  let args : List String
+      args = case args' of
+        h :: t => t
+        []     => [] -- this should not happen
+
   (conf',cmd) <- liftEither $ applyArgs c cur ini args
   conf        <- adjConfig cmd conf'
 

--- a/src/Pack/Config/Types.idr
+++ b/src/Pack/Config/Types.idr
@@ -492,7 +492,7 @@ readSingle read = parseSingleMaybe (Just . read)
 
 export
 Arg a => Arg (Maybe a) where
-  argDesc_ = "[ \{argDesc a} ]"
+  argDesc_ = "[\{argDesc a}]"
 
   readArg ss = case readArg {a} ss of
     Nothing      => Just (Nothing, ss)
@@ -525,7 +525,7 @@ Arg PkgName where
 
 export %inline
 Arg PkgType where
-  argDesc_ = "[lib | app]"
+  argDesc_ = "<lib | app>"
   readArg = parseSingle readPkgType
 
 export %inline
@@ -612,7 +612,7 @@ args {ts = x :: xs} (p :: ps) ss = do
   pure (v :: vs)
 
 argsDesc : CurDir => Command c => Maybe c -> String
-argsDesc Nothing  = "[<args>]"
+argsDesc Nothing  = " [<args>]"
 argsDesc (Just x) = fastConcat $ go (readArgs x)
   where go : All Arg ts -> List String
         go [] = []
@@ -625,7 +625,7 @@ export
 usageHeader : CurDir => Command c => Maybe c -> String
 usageHeader cmd =
   let nm      := maybe "<cmd>" cmdName cmd
-   in "Usage: \{appName {c}} [options] \{nm} \{argsDesc cmd}"
+   in "Usage: \{appName {c}} [options] \{nm}\{argsDesc cmd}"
 
 ind : String -> String
 ind = unlines . map (indent 2) . lines
@@ -669,7 +669,7 @@ readCWA :  Command c
 readCWA x ss =
   let readers := readArgs x
       Just as := args readers ss
-        | Nothing => Left (InvalidCmdArgs (cmdName x) ss $ usageDesc $ Just x)
+        | Nothing => Left (InvalidCmdArgs (cmdName x) ss $ usageHeader $ Just x)
    in Right (x ** as)
 
 ||| Convenience alias for `readCommand_` with an explicit
@@ -682,7 +682,7 @@ readCommand :  (0 c : Type)
             -> Either PackErr (CommandWithArgs c)
 readCommand c cd []       = readCWA defaultCommand []
 readCommand c cd (h :: t) = case readCommand_ {c} h of
-  Nothing => Left (UnknownCommand h $ usage {c})
+  Nothing => Left (UnknownCommand h $ usageDesc {c} Nothing)
   Just x  => readCWA x t
 
 ||| Some commands overwrite certain aspects of the user-defined

--- a/src/Pack/Config/Types.idr
+++ b/src/Pack/Config/Types.idr
@@ -469,10 +469,12 @@ interface Arg (0 a : Type) where
   argDesc_ : String
   readArg  : List String -> Maybe (a, List String)
 
+||| Utility version of `argDesc_` with an explicit erased type argument.
 public export %inline
 argDesc : (0 a : Type) -> Arg a => String
 argDesc a = argDesc_ {a}
 
+||| Utility for implementing `readArg` via a function reading a single string.
 export
 parseSingleMaybe :  (read : String -> Maybe a)
                  -> List String
@@ -480,12 +482,14 @@ parseSingleMaybe :  (read : String -> Maybe a)
 parseSingleMaybe read []       = Nothing
 parseSingleMaybe read (h :: t) = (,t) <$> read h
 
+||| Utility for implementing `readArg` via a function reading a single string.
 export %inline
 parseSingle :  (read : String -> Either e a)
             -> List String
             -> Maybe (a, List String)
 parseSingle read = parseSingleMaybe (eitherToMaybe . read)
 
+||| Utility for implementing `readArg` via a function reading a single string.
 export %inline
 readSingle :  (read : String -> a) -> List String -> Maybe (a, List String)
 readSingle read = parseSingleMaybe (Just . read)
@@ -561,6 +565,14 @@ Arg String where
 ||| because both pack and pack-admin accept different types of
 ||| commands, but both use the same functionality for reading
 ||| the application config based on the command they use.
+|||
+||| A command `c` is expected to be an enum type. This interface provides
+||| a name and detailed description for each command, as well as the types of
+||| arguments a command takes.
+|||
+||| This allows us to generate useful error messages when the wrong type
+||| of argument is passed to a command. It also allows us to implement the
+||| parsing of commands only once.
 public export
 interface Command c where
   ||| The command to use if only command line options but
@@ -630,7 +642,7 @@ usageHeader cmd =
 ind : String -> String
 ind = unlines . map (indent 2) . lines
 
-||| Detailed description of using the given command.
+||| Detailed description how to use the given command.
 |||
 ||| This is a general description of the application
 ||| in case the argument is `Nothing`.
@@ -656,7 +668,7 @@ public export
 0 Args : Command c => c -> Type
 Args cmd = All I (ArgTypes cmd)
 
-||| A pack command together with its list of command line arguments
+||| A pack command together with its list of arguments
 public export
 0 CommandWithArgs : (c : Type) -> Command c => Type
 CommandWithArgs c = DPair c Args

--- a/src/Pack/Config/Types.idr
+++ b/src/Pack/Config/Types.idr
@@ -1,8 +1,10 @@
 module Pack.Config.Types
 
 import Control.Monad.Either
+import Data.Either
 import Data.List
 import Data.IORef
+import public Data.List.Quantifiers
 import Data.Maybe
 import Data.SortedMap as SM
 import Idris.Package.Types
@@ -458,6 +460,100 @@ idrisEnvToEnv : (e : IdrisEnv) => Env
 idrisEnvToEnv = e.env
 
 --------------------------------------------------------------------------------
+--          Command Arguments
+--------------------------------------------------------------------------------
+
+||| An interface for parsing the argument list of a pack command
+public export
+interface Arg (0 a : Type) where
+  argDesc_ : String
+  readArg  : List String -> Maybe (a, List String)
+
+public export %inline
+argDesc : (0 a : Type) -> Arg a => String
+argDesc a = argDesc_ {a}
+
+export
+parseSingleMaybe :  (read : String -> Maybe a)
+                 -> List String
+                 -> Maybe (a, List String)
+parseSingleMaybe read []       = Nothing
+parseSingleMaybe read (h :: t) = (,t) <$> read h
+
+export %inline
+parseSingle :  (read : String -> Either e a)
+            -> List String
+            -> Maybe (a, List String)
+parseSingle read = parseSingleMaybe (eitherToMaybe . read)
+
+export %inline
+readSingle :  (read : String -> a) -> List String -> Maybe (a, List String)
+readSingle read = parseSingleMaybe (Just . read)
+
+export
+Arg a => Arg (Maybe a) where
+  argDesc_ = "[ \{argDesc a} ]"
+
+  readArg ss = case readArg {a} ss of
+    Nothing      => Just (Nothing, ss)
+    Just (v,ss') => Just (Just v, ss')
+
+export
+(cd : CurDir) => Arg (File Abs) where
+  argDesc_ = "<file>"
+  readArg = parseSingle (readAbsFile curDir)
+
+export
+(cd : CurDir) => Arg PkgOrIpkg where
+  argDesc_ = "<pkg or .ipkg>"
+  readArg = readSingle $ \s => case readAbsFile curDir s of
+    Left  _ => Pkg $ MkPkgName s
+    Right f =>
+      if isIpkgBody f.file
+           then Ipkg f
+           else Pkg $ MkPkgName s
+
+export %inline
+(cd : CurDir) => Arg CurDir where
+  argDesc_ = ""
+  readArg ss = Just (cd, ss)
+
+export %inline
+Arg PkgName where
+  argDesc_ = "<pkg>"
+  readArg = readSingle MkPkgName
+
+export %inline
+Arg PkgType where
+  argDesc_ = "[lib | app]"
+  readArg = parseSingle readPkgType
+
+export %inline
+Arg CmdArgList where
+  argDesc_ = "[<args>]"
+  readArg ss = Just (fromStrList ss, [])
+
+export %inline
+Arg (List PkgName) where
+  argDesc_ = "[<pkgs>]"
+  readArg ss = Just (map MkPkgName ss, [])
+
+export %inline
+Arg Body where
+  argDesc_ = "<file name>"
+  readArg = parseSingle readBody
+
+export %inline
+Arg DBName where
+  argDesc_ = "<db>"
+  readArg = parseSingle readDBName
+
+export %inline
+Arg String where
+  argDesc_ = "<str>"
+  readArg = readSingle id
+
+--------------------------------------------------------------------------------
 --          Command
 --------------------------------------------------------------------------------
 
@@ -469,37 +565,136 @@ public export
 interface Command c where
   ||| The command to use if only command line options but
   ||| not command is given.
-  defaultCommand_ : c
+  defaultCommand : c
+
+  ||| Name of the application in question
+  appName : String
+
+  ||| Name of command in question
+  cmdName : c -> String
 
   ||| The default log level to use.
   defaultLevel    : c -> LogLevel
+
+  ||| Detailed usage description of the command
+  desc : c -> String
+
+  ||| General usage of the application in question
+  usage : Lazy String
+
+  ||| Types of arguments required by the given command
+  0 ArgTypes : c -> List Type
+
+  ||| Tries to read a command from a String
+  readCommand_ : String -> Maybe c
+
+  ||| List of argument readers for the current command
+  readArgs : CurDir => (cmd : c) -> All Arg (ArgTypes cmd)
 
   ||| Some commands overwrite certain aspects of the user-defined
   ||| config. For instance, `pack switch latest` must overwrite the
   ||| package collection read from the `pack.toml` files with the
   ||| latest package collection available.
-  adjConfig :  HasIO io
-            => PackDir
-            => TmpDir
-            => c
-            -> MetaConfig
-            -> EitherT PackErr io MetaConfig
+  adjConfig_ :  HasIO io
+             => PackDir
+             => TmpDir
+             => (cmd : c)
+             -> All I (ArgTypes cmd)
+             -> MetaConfig
+             -> EitherT PackErr io MetaConfig
 
-  ||| Tries to read a command from a list of command line arguments.
-  readCommand_ : CurDir -> List String -> Either PackErr c
+args : All Arg ts -> CurDir => List String -> Maybe (All I ts)
+args [] []       = Just []
+args [] (_ :: _) = Nothing
+args {ts = x :: xs} (p :: ps) ss = do
+  (v,ss') <- readArg {a = x} ss
+  vs      <- args ps ss'
+  pure (v :: vs)
 
-||| Convenience alias for `defaultCommand_` with an explicit
-||| erased argument for the command type.
-export %inline
-defaultCommand : (0 c : Type) -> Command c => c
-defaultCommand _ = defaultCommand_
+argsDesc : CurDir => Command c => Maybe c -> String
+argsDesc Nothing  = "[<args>]"
+argsDesc (Just x) = fastConcat $ go (readArgs x)
+  where go : All Arg ts -> List String
+        go [] = []
+        go {ts = x :: xs} (p :: ps) = case argDesc_ {a = x} of
+          "" => go ps
+          s  => (" " ++ s) :: go ps
+
+||| Header line for a usage string
+export
+usageHeader : CurDir => Command c => Maybe c -> String
+usageHeader cmd =
+  let nm      := maybe "<cmd>" cmdName cmd
+   in "Usage: \{appName {c}} [options] \{nm} \{argsDesc cmd}"
+
+ind : String -> String
+ind = unlines . map (indent 2) . lines
+
+||| Detailed description of using the given command.
+|||
+||| This is a general description of the application
+||| in case the argument is `Nothing`.
+export
+usageDesc : CurDir => Command c => Maybe c -> String
+usageDesc m = case m of
+  Just cmd =>
+    """
+    \{usageHeader m}
+
+    \{ind $ desc cmd}
+    """
+
+  Nothing =>
+    """
+    \{usageHeader m}
+
+    \{usage {c}}
+    """
+
+||| Type of arguments expected by the given command
+public export
+0 Args : Command c => c -> Type
+Args cmd = All I (ArgTypes cmd)
+
+||| A pack command together with its list of command line arguments
+public export
+0 CommandWithArgs : (c : Type) -> Command c => Type
+CommandWithArgs c = DPair c Args
+
+readCWA :  Command c
+        => CurDir
+        => (cmd : c)
+        -> List String
+        -> Either PackErr (CommandWithArgs c)
+readCWA x ss =
+  let readers := readArgs x
+      Just as := args readers ss
+        | Nothing => Left (InvalidCmdArgs (cmdName x) ss $ usageDesc $ Just x)
+   in Right (x ** as)
 
 ||| Convenience alias for `readCommand_` with an explicit
 ||| erased argument for the command type.
-export %inline
+export
 readCommand :  (0 c : Type)
             -> Command c
             => CurDir
             -> List String
-            -> Either PackErr c
-readCommand _ = readCommand_
+            -> Either PackErr (CommandWithArgs c)
+readCommand c cd []       = readCWA defaultCommand []
+readCommand c cd (h :: t) = case readCommand_ {c} h of
+  Nothing => Left (UnknownCommand h $ usage {c})
+  Just x  => readCWA x t
+
+||| Some commands overwrite certain aspects of the user-defined
+||| config. For instance, `pack switch latest` must overwrite the
+||| package collection read from the `pack.toml` files with the
+||| latest package collection available.
+export %inline
+adjConfig :  HasIO io
+          => Command c
+          => PackDir
+          => TmpDir
+          => CommandWithArgs c
+          -> MetaConfig
+          -> EitherT PackErr io MetaConfig
+adjConfig (command ** args) = adjConfig_ command args

--- a/src/Pack/Core/Types.idr
+++ b/src/Pack/Core/Types.idr
@@ -834,16 +834,16 @@ printErr (ErroneousArg err) = err
 
 printErr (UnknownCommand cmd usage) =
   """
-  Unknown command: \{cmd}
+  Unknown command: "\{cmd}"
 
-  Usage: \{usage}
+  \{usage}
   """
 
 printErr (InvalidCmdArgs cmd args usage) =
   """
-  Invalid argument(s) for command \{cmd}.
+  Invalid argument(s) for command `\{cmd}`.
 
-  Usage: \{usage}
+  \{usage}
   """
 
 printErr BuildMany =

--- a/src/Pack/Core/Types.idr
+++ b/src/Pack/Core/Types.idr
@@ -282,6 +282,17 @@ Cast PkgName (Path Rel) where
   cast = toRelPath . value
 
 --------------------------------------------------------------------------------
+--          PkgOrIpkg
+--------------------------------------------------------------------------------
+
+||| Several pack commands operat either on a pack package or a local
+||| `.ipkg` file. This data type represents such command line arguments.
+public export
+data PkgOrIpkg : Type where
+  Pkg :  PkgName -> PkgOrIpkg
+  Ipkg : File Abs -> PkgOrIpkg
+
+--------------------------------------------------------------------------------
 --          Package Type
 --------------------------------------------------------------------------------
 
@@ -704,9 +715,14 @@ data PackErr : Type where
   ||| (or something that isn't a local package).
   BuildMany : PackErr
 
-  ||| Unknown command or sequence of options
-  ||| entered on the command line
-  UnknownCommand : List String -> PackErr
+  ||| Unknown pack command
+  UnknownCommand : String -> (usage : String) -> PackErr
+
+  ||| Unknown pack command
+  InvalidCmdArgs :  (cmd   : String)
+                 -> (args  : List String)
+                 -> (usage : String)
+                 -> PackErr
 
   ||| Trying to clone a repository into an existing
   ||| directory.
@@ -816,7 +832,19 @@ printErr (InvalidArgs args) = "Invalid command line args: \{unwords args}"
 
 printErr (ErroneousArg err) = err
 
-printErr (UnknownCommand cmd) = "Unknown command: \{unwords cmd}"
+printErr (UnknownCommand cmd usage) =
+  """
+  Unknown command: \{cmd}
+
+  Usage: \{usage}
+  """
+
+printErr (InvalidCmdArgs cmd args usage) =
+  """
+  Invalid argument(s) for command \{cmd}.
+
+  Usage: \{usage}
+  """
 
 printErr BuildMany =
   "Can only build or typecheck a single Idris2 package given as an `.ipkg` file."

--- a/src/Pack/Runner/Database.idr
+++ b/src/Pack/Runner/Database.idr
@@ -101,10 +101,10 @@ parseLibIpkg p loc = parseIpkgFile p loc >>= safe
 export
 findAndParseLocalIpkg :  HasIO io
                       => (e    : Env)
-                      => (file : Either (File Abs) PkgName)
+                      => (file : PkgOrIpkg)
                       -> EitherT PackErr io (Desc Safe)
-findAndParseLocalIpkg (Left p)  = parseLibIpkg p p
-findAndParseLocalIpkg (Right n) =
+findAndParseLocalIpkg (Ipkg p) = parseLibIpkg p p
+findAndParseLocalIpkg (Pkg n)  =
   case lookup n allPackages of
     Nothing                 => throwE (UnknownPkg n)
     Just (Local dir ipkg _) => let p = dir </> ipkg in parseLibIpkg p p

--- a/src/Pack/Runner/Develop.idr
+++ b/src/Pack/Runner/Develop.idr
@@ -126,36 +126,24 @@ exec file args e = do
 
 ||| Build a local library given as an `.ipkg` file.
 export covering %inline
-build :  HasIO io
-      => Either (File Abs) PkgName
-      -> IdrisEnv
-      -> EitherT PackErr io ()
+build : HasIO io => PkgOrIpkg -> IdrisEnv -> EitherT PackErr io ()
 build f e = findAndParseLocalIpkg f >>= runIdrisOn ["--build"]
 
 ||| Install dependencies of a local `.ipkg` file or package name
 export covering
-buildDeps :  HasIO io
-          => Either (File Abs) PkgName
-          -> IdrisEnv
-          -> EitherT PackErr io ()
+buildDeps : HasIO io => PkgOrIpkg -> IdrisEnv -> EitherT PackErr io ()
 buildDeps f e = do
   d <- findAndParseLocalIpkg f
   installDeps d
 
 ||| Typecheck a local library given as an `.ipkg` file or package name
 export covering %inline
-typecheck :  HasIO io
-          => Either (File Abs) PkgName
-          -> IdrisEnv
-          -> EitherT PackErr io ()
+typecheck : HasIO io => PkgOrIpkg -> IdrisEnv -> EitherT PackErr io ()
 typecheck f e = findAndParseLocalIpkg f >>= runIdrisOn ["--typecheck"]
 
 ||| Cleanup a local library given as an `.ipkg` file or package name
 export covering %inline
-clean :  HasIO io
-          => Either (File Abs) PkgName
-          -> IdrisEnv
-          -> EitherT PackErr io ()
+clean : HasIO io => PkgOrIpkg -> IdrisEnv -> EitherT PackErr io ()
 clean f e = findAndParseLocalIpkg f >>= libPkg [] ["--clean"]
 
 ||| Build and execute a local `.ipkg` file.
@@ -168,7 +156,7 @@ runIpkg :  HasIO io
 runIpkg p args e = do
   d        <- parseLibIpkg p p
   Just exe <- pure (execPath d) | Nothing => throwE (NoAppIpkg p)
-  build (Left p) e
+  build (Ipkg p) e
   case ipkgCodeGen d.desc of
     Node => sys $ ["node", exe] ++ args
     _    => sys $ [exe] ++ args

--- a/src/Pack/Runner/Install.idr
+++ b/src/Pack/Runner/Install.idr
@@ -289,6 +289,20 @@ install ps = do
     for_ all $ \case Lib rl  => installDocs rl
                      App _ _ => pure ()
 
+||| Install the given list of libraries, by first
+||| resolving each of them and then creating a build plan including
+||| all dependencies of the lot.
+export covering %inline
+installLibs : HasIO io => IdrisEnv => List PkgName -> EitherT PackErr io ()
+installLibs = install . map (Library,)
+
+||| Install the given list of applications, by first
+||| resolving each of them and then creating a build plan including
+||| all dependencies of the lot.
+export covering %inline
+installApps : HasIO io => IdrisEnv => List PkgName -> EitherT PackErr io ()
+installApps = install . map (App True,)
+
 ||| Install the (possibly transitive) dependencies of the given
 ||| loaded `.ipkg` file.
 export covering
@@ -356,10 +370,20 @@ removeLib n = do
   info "Removing library \{n}"
   rmDir (pkgInstallDir rl.name rl.pkg rl.desc)
 
-||| Remove a library or application.
+||| Remove the given libs or apps
 export covering
 remove : HasIO io => Env => List (PkgType,PkgName) -> EitherT PackErr io ()
 remove ps = do
   ref <- emptyCache
   for_ ps  $ \case (Lib,n) => removeLib n
                    (Bin,n) => removeApp n
+
+||| Remove the given libs
+export covering
+removeLibs : HasIO io => Env => List PkgName -> EitherT PackErr io ()
+removeLibs = remove . map (Lib,)
+
+||| Remove the given apps
+export covering
+removeApps : HasIO io => Env => List PkgName -> EitherT PackErr io ()
+removeApps = remove . map (Bin,)


### PR DESCRIPTION
The goal of this PR is to give clearer error messages in case of invalid command arguments as well as to provide detailed per-command descriptions via `pack help <cmd>` instead of listing all commands plus their description with `pack help`. In addition, the way we parse commands and their arguments has been completely overhauled.

Once this is ready, it should fix #165 and supersed #143, which seems to have stalled.

Note: This PR does *not* change the order in which pack parses command-line options and commands, so this is unrelated to #134.