### PR TITLE
[ fix ] dont prompt when there is nothing to clean

### DIFF
--- a/src/Pack/Runner/Database.idr
+++ b/src/Pack/Runner/Database.idr
@@ -347,11 +347,12 @@ garbageCollector e = do
 
   let all := ds ++ ps ++ ts
 
-  when e.config.gcPrompt $ do
+  when (e.config.gcPrompt && not (null all)) $ do
     let msg := "The following directories will be deleted. Continue (yes/*no)?"
     "yes" <- promptMany Warning msg (interpolate <$> all)
       | _ => throwE SafetyAbort
     pure ()
+  when (null all) $ info "Nothing to clean up."
   for_ all rmDir
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This is a follow-up on #196 , fixing an invisible prompt and waiting `getLine` call in case no directories need to be removed.