### PR TITLE
[ new ] delete build dir if outdated

### DIFF
--- a/src/Pack/Runner/Develop.idr
+++ b/src/Pack/Runner/Develop.idr
@@ -14,12 +14,13 @@ import Pack.Runner.Query
 covering
 runIdrisOn :  HasIO io
            => IdrisEnv
-           => (cmd : CmdArgList)
+           => (cleanBuild : Bool)
+           -> (cmd        : CmdArgList)
            -> Desc Safe
            -> EitherT PackErr io ()
-runIdrisOn c d = do
+runIdrisOn cleanBuild c d = do
   installDeps d
-  libPkg [] c d
+  libPkg [] cleanBuild c d
 
 findIpkg :  HasIO io
          => WithIpkg
@@ -127,7 +128,7 @@ exec file args e = do
 ||| Build a local library given as an `.ipkg` file.
 export covering %inline
 build : HasIO io => PkgOrIpkg -> IdrisEnv -> EitherT PackErr io ()
-build f e = findAndParseLocalIpkg f >>= runIdrisOn ["--build"]
+build f e = findAndParseLocalIpkg f >>= runIdrisOn True ["--build"]
 
 ||| Install dependencies of a local `.ipkg` file or package name
 export covering
@@ -139,12 +140,12 @@ buildDeps f e = do
 ||| Typecheck a local library given as an `.ipkg` file or package name
 export covering %inline
 typecheck : HasIO io => PkgOrIpkg -> IdrisEnv -> EitherT PackErr io ()
-typecheck f e = findAndParseLocalIpkg f >>= runIdrisOn ["--typecheck"]
+typecheck f e = findAndParseLocalIpkg f >>= runIdrisOn True ["--typecheck"]
 
 ||| Cleanup a local library given as an `.ipkg` file or package name
 export covering %inline
 clean : HasIO io => PkgOrIpkg -> IdrisEnv -> EitherT PackErr io ()
-clean f e = findAndParseLocalIpkg f >>= libPkg [] ["--clean"]
+clean f e = findAndParseLocalIpkg f >>= libPkg [] False ["--clean"]
 
 ||| Build and execute a local `.ipkg` file.
 export covering


### PR DESCRIPTION
This is a potential fix for #167, although I haven't tested it in earnest yet. This might be made superfluous by idris-lang/Idris2#2684 in which case I'll just delete it.