### PR TITLE
[ cleanup ] Replace hacky way of current dir passing to direct one

### DIFF
--- a/src/Pack/Config/Types.idr
+++ b/src/Pack/Config/Types.idr
@@ -525,11 +525,6 @@ export
            else Pkg $ MkPkgName s
 
 export %inline
-(cd : CurDir) => Arg CurDir where
-  argDesc_ = ""
-  readArg ss = Just (cd, ss)
-
-export %inline
 Arg PkgName where
   argDesc_ = "<pkg>"
   readArg = readSingle MkPkgName
@@ -634,10 +629,7 @@ argsDesc : CurDir => Command c => Maybe c -> String
 argsDesc Nothing  = " [<args>]"
 argsDesc (Just x) = fastConcat $ go (readArgs x)
   where go : All Arg ts -> List String
-        go [] = []
-        go {ts = x :: xs} (p :: ps) = case argDesc_ {a = x} of
-          "" => go ps
-          s  => (" " ++ s) :: go ps
+        go = forget . mapProperty (\p => " " ++ argDesc_ @{p})
 
 ||| Header line for a usage string
 export

--- a/src/Pack/Runner.idr
+++ b/src/Pack/Runner.idr
@@ -64,7 +64,7 @@ Command Cmd where
   ArgTypes Remove           = [List PkgName]
   ArgTypes RemoveApp        = [List PkgName]
   ArgTypes Run              = [PkgOrIpkg, CmdArgList]
-  ArgTypes New              = [CurDir, PkgType, Body]
+  ArgTypes New              = [PkgType, Body]
   ArgTypes Update           = []
   ArgTypes Fetch            = []
   ArgTypes PackagePath      = []
@@ -165,7 +165,7 @@ runCmd = do
     (DataPath ** [])          => env mc fetch >>= packageDataDirs >>= putStrLn
     (AppPath ** [n])          => env mc fetch >>= appPath n
     (Info ** [])              => env mc fetch >>= printInfo
-    (New  ** [dir,pty,p])     => idrisEnv mc fetch >>= new dir pty p
+    (New ** [pty,p])          => idrisEnv mc fetch >>= new cd pty p
     (Switch ** [db])          => do
       env <- idrisEnv mc fetch
       install []


### PR DESCRIPTION
This, besides all, removed a "special value" (empty string) hack of `argDesc_`, and simplifies a function implementation, that traverses list of commands.