### PR TITLE
[ fix ] prompt before deleting depended-on packages

### DIFF
--- a/src/Pack/Database/Types.idr
+++ b/src/Pack/Database/Types.idr
@@ -285,6 +285,13 @@ namespace ResolveLib
   dependencies : ResolvedLib t -> List PkgName
   dependencies rp = dependencies rp.desc
 
+  ||| Check if the given library is installed
+  export
+  isInstalled : ResolvedLib t -> Bool
+  isInstalled rl = case rl.status of
+    Missing => False
+    _       => True
+
 namespace AppStatus
   ||| Installation status of an Idris app. Local apps can be
   ||| `Outdated`, if some of their source files contain changes newer

--- a/src/Pack/Runner/Install.idr
+++ b/src/Pack/Runner/Install.idr
@@ -385,8 +385,10 @@ covering
 removeLib : HasIO io => Env => PkgName -> EitherT PackErr io ()
 removeLib n = do
   rl <- resolveLib n
-  info "Removing library \{n}"
-  rmDir (pkgInstallDir rl.name rl.pkg rl.desc)
+  case isInstalled rl of
+    True  => info "Removing library \{n}" >>
+             rmDir (pkgInstallDir rl.name rl.pkg rl.desc)
+    False => warn "Package \{n} is not installed. Ignoring."
 
 ||| Remove the given libs or apps
 export covering
@@ -399,7 +401,9 @@ remove ps = do
 ||| Remove the given libs
 export covering
 removeLibs : HasIO io => Env => List PkgName -> EitherT PackErr io ()
-removeLibs = remove . map (Lib,)
+removeLibs ns = do
+  checkDeletable ns
+  remove $ map (Lib,) ns
 
 ||| Remove the given apps
 export covering

--- a/src/Pack/Runner/Query.idr
+++ b/src/Pack/Runner/Query.idr
@@ -65,7 +65,7 @@ installedApp qp = case map status qp.app of
   Nothing           => False
 
 covering
-resolve : HasIO io => LibCache => Env => PkgName -> EitherT PackErr io QPkg
+resolve : HasIO io => Env => PkgName -> EitherT PackErr io QPkg
 resolve n = do
   lib <- resolveLib n
   Just exe <- pure (exec lib.desc) | Nothing => pure (QP lib Nothing)
@@ -77,9 +77,7 @@ pkgNames = keys allPackages
 
 export covering
 resolveAll : HasIO io => Env => EitherT PackErr io (List QPkg)
-resolveAll = do
-  ref <- emptyCache
-  traverse resolve pkgNames
+resolveAll = traverse resolve pkgNames
 
 --------------------------------------------------------------------------------
 --         Queries


### PR DESCRIPTION
This fixes #29 and adds a warning when trying to delete a lib that was not installed in the first place.