### PR TITLE
[ minor, fix ] Fix a hint of the CLI help for package kind

### DIFF
--- a/src/Pack/Config/Types.idr
+++ b/src/Pack/Config/Types.idr
@@ -536,7 +536,7 @@ Arg PkgName where
 
 export %inline
 Arg PkgType where
-  argDesc_ = "<lib | app>"
+  argDesc_ = "<lib | bin>"
   readArg = parseSingle readPkgType
 
 export %inline


### PR DESCRIPTION
Or else, it gives strange error: write `app`, it says "wrong, use `lib` or `app`".