### PR TITLE
[ log ] set log-level to Build when checking DB

### DIFF
--- a/src/Pack/Admin/Runner.idr
+++ b/src/Pack/Admin/Runner.idr
@@ -71,7 +71,7 @@ Command ACmd where
 
   cmdName = name
 
-  defaultLevel CheckDB  = Info
+  defaultLevel CheckDB  = Build
   defaultLevel FromHEAD = Info
   defaultLevel Help     = Warning
 


### PR DESCRIPTION
The pack-db CI is rather quiet at the moment. This changes it.