### PR TITLE
[ new ] Add command for running test suites

### DIFF
--- a/src/Pack/Admin/Report/Types.idr
+++ b/src/Pack/Admin/Report/Types.idr
@@ -55,13 +55,13 @@ apiLink : PkgName -> String
 apiLink p = "https://stefan-hoeck.github.io/idris2-pack-docs/docs/\{p}/index.html"
 
 url : (e : Env) => Package -> URL
-url (GitHub u _ _ _) = u
-url (Local dir ipkg pkgPath) = MkURL "\{dir}"
+url (GitHub u _ _ _ _) = u
+url (Local dir ipkg pkgPath _) = MkURL "\{dir}"
 url (Core _) = e.db.idrisURL
 
 commit : (e : Env) => Package -> Commit
-commit (GitHub _ c _ _) = c
-commit (Local dir ipkg pkgPath) = ""
+commit (GitHub _ c _ _ _) = c
+commit (Local dir ipkg pkgPath _) = ""
 commit (Core _) = e.db.idrisCommit
 
 succLine : Env => SafeLib -> String

--- a/src/Pack/CmdLn/Completion.idr
+++ b/src/Pack/CmdLn/Completion.idr
@@ -129,6 +129,7 @@ opts x "modules"          = prefixOnlyIfNonEmpty x <$> pure packages
 opts x "check-db"         = prefixOnlyIfNonEmpty x <$> collections
 opts x "run"              = prefixOnlyIfNonEmpty x <$> packagesOrIpkg
 opts x "install"          = prefixOnlyIfNonEmpty x <$> pure packages
+opts x "test"             = prefixOnlyIfNonEmpty x <$> pure packages
 opts x "install-app"      = prefixOnlyIfNonEmpty x <$> apps
 opts x "remove"           = prefixOnlyIfNonEmpty x <$> installedLibs
 opts x "remove-app"       = prefixOnlyIfNonEmpty x <$> installedApps

--- a/src/Pack/CmdLn/Types.idr
+++ b/src/Pack/CmdLn/Types.idr
@@ -63,6 +63,7 @@ data Cmd : Type where
   Remove           : Cmd
   RemoveApp        : Cmd
   Run              : Cmd
+  Test             : Cmd
   New              : Cmd
   Update           : Cmd
   Fetch            : Cmd
@@ -107,6 +108,7 @@ commands =
   , Remove
   , RemoveApp
   , Run
+  , Test
   , New
   , Update
   , Fetch
@@ -139,6 +141,7 @@ name InstallApp       = "install-app"
 name Remove           = "remove"
 name RemoveApp        = "remove-app"
 name Run              = "run"
+name Test             = "test"
 name New              = "new"
 name Update           = "update"
 name Fetch            = "fetch"
@@ -227,6 +230,19 @@ cmdDesc Run              = """
   will be built and run locally without installing them.
 
   To change the codegen to use, use the `--cg` command-line option.
+  """
+
+cmdDesc Test              = """
+  Run a test suite as specified in a package description's `test` field.
+
+  The `test` field should consist of a file path relative to a package's
+  root directory point to the test suite's `.ipkg` file:
+
+  [custom.all.json]
+  type   = "local"
+  path   = "."
+  ipkg   = "json.ipkg"
+  test   = "test/test.ipkg"
   """
 
 cmdDesc New              = """
@@ -391,6 +407,7 @@ cmdInCommands InstallApp       = %search
 cmdInCommands Remove           = %search
 cmdInCommands RemoveApp        = %search
 cmdInCommands Run              = %search
+cmdInCommands Test             = %search
 cmdInCommands New              = %search
 cmdInCommands Update           = %search
 cmdInCommands Fetch            = %search

--- a/src/Pack/Config/Environment.idr
+++ b/src/Pack/Config/Environment.idr
@@ -154,9 +154,9 @@ idrisDataDir = idrisInstallDir /> "support"
 ||| Directory where an installed library or app goes
 export %inline
 pkgPrefixDir : PackDir => DB => PkgName -> Package -> Path Abs
-pkgPrefixDir n (GitHub _ c _ _) = commitDir <//> n <//> c
-pkgPrefixDir n (Local _ _ _)    = commitDir </> "local" <//> n
-pkgPrefixDir n (Core _)         = idrisPrefixDir
+pkgPrefixDir n (GitHub _ c _ _ _) = commitDir <//> n <//> c
+pkgPrefixDir n (Local _ _ _ _)    = commitDir </> "local" <//> n
+pkgPrefixDir n (Core _)           = idrisPrefixDir
 
 ||| Directory to be used with the `IDRIS2_PACKAGE_PATH` variable, so that
 ||| Idris finds a library even though it is being installed in a
@@ -220,9 +220,9 @@ pkgInstallDir n p d =
   let vers = db.idrisVersion
       dir  = pkgPrefixDir n p /> idrisDir
    in case p of
-        Core c         => dir /> (c <-> vers)
-        GitHub _ _ _ _ => dir </> pkgRelDir d
-        Local _ _ _    => dir </> pkgRelDir d
+        Core c           => dir /> (c <-> vers)
+        GitHub _ _ _ _ _ => dir </> pkgRelDir d
+        Local _ _ _ _    => dir </> pkgRelDir d
 
 ||| Location of an executable of the given name.
 export

--- a/src/Pack/Database/TOML.idr
+++ b/src/Pack/Database/TOML.idr
@@ -16,12 +16,14 @@ github : FromTOML c => File Abs -> Value -> Either TOMLErr (Package_ c)
 github f v = [| GitHub (valAt "url" f v)
                        (valAt "commit" f v)
                        (valAt "ipkg" f v)
-                       (optValAt "packagePath" f False v) |]
+                       (optValAt "packagePath" f False v)
+                       (maybeValAt "test" f v) |]
 
 local : File Abs -> Value -> Either TOMLErr (Package_ c)
 local f v = [| Local (valAt "path" f v)
                      (valAt "ipkg" f v)
-                     (optValAt "packagePath" f False v) |]
+                     (optValAt "packagePath" f False v)
+                     (maybeValAt "test" f v) |]
 
 package : FromTOML c => File Abs -> Value -> Either TOMLErr (Package_ c)
 package f v = valAt {a = String} "type" f v >>=

--- a/src/Pack/Runner.idr
+++ b/src/Pack/Runner.idr
@@ -35,6 +35,7 @@ Command Cmd where
   defaultLevel Remove           = Build
   defaultLevel RemoveApp        = Build
   defaultLevel Run              = Warning
+  defaultLevel Test             = Build
   defaultLevel Update           = Build
   defaultLevel Fetch            = Build
   defaultLevel PackagePath      = Silence
@@ -64,6 +65,7 @@ Command Cmd where
   ArgTypes Remove           = [List PkgName]
   ArgTypes RemoveApp        = [List PkgName]
   ArgTypes Run              = [PkgOrIpkg, CmdArgList]
+  ArgTypes Test             = [PkgName, CmdArgList]
   ArgTypes New              = [PkgType, Body]
   ArgTypes Update           = []
   ArgTypes Fetch            = []
@@ -106,6 +108,7 @@ Command Cmd where
   readArgs Remove           = %search
   readArgs RemoveApp        = %search
   readArgs Run              = %search
+  readArgs Test             = %search
   readArgs New              = %search
   readArgs Update           = %search
   readArgs Fetch            = %search
@@ -147,6 +150,7 @@ runCmd = do
     (CollectGarbage ** [])    => env mc fetch >>= garbageCollector
     (Run ** [Pkg p,args])     => idrisEnv mc fetch >>= execApp p args
     (Run ** [Ipkg p,args])    => idrisEnv mc fetch >>= runIpkg p args
+    (Test ** [p,args])        => idrisEnv mc fetch >>= runTest p args
     (Exec ** [p,args])        => idrisEnv mc fetch >>= exec p args
     (Repl ** [p])             => idrisEnv mc fetch >>= idrisRepl p
     (Build ** [p])            => idrisEnv mc fetch >>= build p

--- a/src/Pack/Runner/Database.idr
+++ b/src/Pack/Runner/Database.idr
@@ -107,9 +107,9 @@ findAndParseLocalIpkg :  HasIO io
 findAndParseLocalIpkg (Ipkg p) = parseLibIpkg p p
 findAndParseLocalIpkg (Pkg n)  =
   case lookup n allPackages of
-    Nothing                 => throwE (UnknownPkg n)
-    Just (Local dir ipkg _) => let p = dir </> ipkg in parseLibIpkg p p
-    Just _                  => throwE (NotLocalPkg n)
+    Nothing                   => throwE (UnknownPkg n)
+    Just (Local dir ipkg _ _) => let p = dir </> ipkg in parseLibIpkg p p
+    Just _                    => throwE (NotLocalPkg n)
 
 
 ||| Parse an `.ipkg` file representing an application
@@ -164,9 +164,9 @@ withPkgEnv :  HasIO io
              -> Package
              -> (Path Abs -> EitherT PackErr io a)
              -> EitherT PackErr io a
-withPkgEnv n (GitHub u c i _) f = withGit n u c f
-withPkgEnv n (Local d i _)    f = inDir d f
-withPkgEnv n (Core _)         f = withCoreGit f
+withPkgEnv n (GitHub u c i _ _) f = withGit n u c f
+withPkgEnv n (Local d i _ _)    f = inDir d f
+withPkgEnv n (Core _)           f = withCoreGit f
 
 isOutdated : DPair Package PkgStatus -> Bool
 isOutdated (fst ** Outdated) = True
@@ -242,7 +242,7 @@ loadIpkg :  HasIO io
          => PkgName
          -> Package
          -> EitherT PackErr io (Desc U)
-loadIpkg n (GitHub u c i _) =
+loadIpkg n (GitHub u c i _ _) =
   let cache  := ipkgCachePath n c i
       tmpLoc := gitTmpDir n </> i
    in do
@@ -252,8 +252,8 @@ loadIpkg n (GitHub u c i _) =
          when !(fileExists pf) (patch tmpLoc pf)
          copyFile tmpLoc cache
      parseIpkgFile cache tmpLoc
-loadIpkg n (Local d i _)    = parseIpkgFile (d </> i) (d </> i)
-loadIpkg n (Core c)         =
+loadIpkg n (Local d i _ _)    = parseIpkgFile (d </> i) (d </> i)
+loadIpkg n (Core c)           =
   let cache  := coreCachePath c
       tmpLoc := gitTmpDir compiler </> coreIpkgPath c
    in do

--- a/src/Pack/Runner/Install.idr
+++ b/src/Pack/Runner/Install.idr
@@ -195,12 +195,12 @@ installLib rl = case rl.status of
   _         => withPkgEnv rl.name rl.pkg $ \dir =>
     let ipkgAbs := ipkg dir rl.pkg
      in case rl.pkg of
-          GitHub u c ipkg _ => do
+          GitHub u c ipkg _ _ => do
             let cache := ipkgCachePath rl.name c ipkg
             copyFile cache ipkgAbs
             installImpl dir rl
 
-          Local _ _ _ => do
+          Local _ _ _ _ => do
             installImpl dir rl
             write (libTimestamp rl.name rl.pkg) ""
 
@@ -236,13 +236,13 @@ installApp b ra =
       let ipkgAbs := ipkg dir ra.pkg
        in case ra.pkg of
             Core _            => pure ()
-            GitHub u c ipkg b => do
+            GitHub u c ipkg b _ => do
               let cache   := ipkgCachePath ra.name c ipkg
               copyFile cache ipkgAbs
               libPkg [] Build True ["--build"] (notPackIsSafe ra.desc)
               copyApp ra
               when b $ appLink ra.exec ra.name (usePackagePath ra) cg
-            Local _ _ b    => do
+            Local _ _ b _    => do
               libPkg [] Build True ["--build"] (notPackIsSafe ra.desc)
               copyApp ra
               when b $ appLink ra.exec ra.name (usePackagePath ra) cg

--- a/src/Pack/Runner/Query.idr
+++ b/src/Pack/Runner/Query.idr
@@ -128,21 +128,25 @@ appStatus qp = case qp.app of
     , "App          : \{status' st}"
     ]
 
+testFile : Maybe (File Rel) -> List String
+testFile Nothing  = []
+testFile (Just f) = ["Test File    : \{f}"]
+
 details : QPkg -> List String
 details qp = case qp.lib.pkg of
-  GitHub url commit ipkg _ => [
+  GitHub url commit ipkg _ t => [
     "Type         : GitHub project"
   , "URL          : \{url}"
   , "Commit       : \{commit}"
   , "ipkg File    : \{ipkg}"
-  ]
+  ] ++ testFile t
 
-  Local d i _ =>
+  Local d i _ t =>
     let ipkg := toAbsFile d i
      in [ "Type         : Local Idris project"
         , "Location     : \{ipkg.parent}"
         , "ipkg File    : \{ipkg.file}"
-        ]
+        ] ++ testFile t
 
   Core _            => [
     "Type         : Idris core package"


### PR DESCRIPTION
With this PR, a new `test` field is added to package descriptions pointing to a single `.ipkg` file used for running tests via `pack test [pkg] [args]`. At the moment, I keep this very basic: Only a single test suite is supported, but this may be  relaxed in the future. In addition, while it is possible to pass command-line arguments to the test suite, it is assumed that the app also runs without arguments when running `pack-admin check-db`.

Note: It is already easily possible to specify local packages in local `pack.toml` files, which can then serve as test runners. With this new command, it is now also possible to run test suites automatically when building the nightly package collections. In addition, it makes the default case of a single Idris test suite a bit less cumbersome to setup.