### PR TITLE
[ pack-admin ] check-db does not build docks

### DIFF
--- a/src/Pack/Admin/Runner.idr
+++ b/src/Pack/Admin/Runner.idr
@@ -83,8 +83,8 @@ Command ACmd where
 
   adjConfig_ CheckDB [db,_] c = pure $ {
       collection   := db
-    , withDocs     := True
-    , useKatla     := True
+    , withDocs     := False
+    , useKatla     := False
     , safetyPrompt := False
     } c
 


### PR DESCRIPTION
The CI of pack-db and pack-docs are buggy and need an overhaul. The first step is to turn off docs and make test-success optional to at least get the nightly collections to build again.