### PR TITLE
[ config ] specify default log levels in pack.toml

### DIFF
--- a/src/Pack/CmdLn/Opts.idr
+++ b/src/Pack/CmdLn/Opts.idr
@@ -223,7 +223,10 @@ applyArgs c dir init args =
   case getOpt RequireOrder descs args of
        MkResult opts n  []      []       => do
          cmd  <- readCommand c dir n
-         let init' = {logLevel := defaultLevel (fst cmd)} init
+         let lvl_m := lookup (cmdName $ fst cmd) init.levels
+             dflt  := defaultLevel $ fst cmd
+
+             init' = {logLevel := fromMaybe dflt lvl_m} init
          conf <- foldlM (\c,f => f dir c) init' opts
          Right (conf, cmd)
 

--- a/src/Pack/Config/TOML.idr
+++ b/src/Pack/Config/TOML.idr
@@ -57,6 +57,7 @@ FromTOML UserConfig where
                   (pure Nothing)
                   (maybeValAt "idris2.codegen" f v)
                   (pure Nothing)
+                  (maybeValAt "log" f v)
       |]
 
 ||| Initial content of an auto-generated `PACK_DIR/user/pack.toml` file.
@@ -181,4 +182,12 @@ initToml scheme db = """
   # url    = "https://github.com/cuddlefishie/toml-idr"
   # commit = "eb7a146f565276f82ebf30cb6d5502e9f65dcc3c"
   # ipkg   = "toml.ipkg"
+
+  # Uncomment and adjust the following entries to specify the
+  # default log level associated with each pack command.
+  # [log]
+
+  # exec = "debug"
+  # run  = "info"
+  # test = "warning"
   """

--- a/src/Pack/Config/Types.idr
+++ b/src/Pack/Config/Types.idr
@@ -228,6 +228,9 @@ record Config_ (f : Type -> Type) (c : Type) where
   ||| Name of output file when compiling Idris source files
   output       : f Body
 
+  ||| Default LogLevels for different commands
+  levels       : f (SortedMap String LogLevel)
+
 ||| Configuration with mandatory fields.
 public export
 0 IConfig : Type -> Type
@@ -336,6 +339,7 @@ init coll = MkConfig {
   , logLevel     = Warning
   , codegen      = Default
   , output       = "_tmppack"
+  , levels       = empty
   }
 
 infixl 7 `update`
@@ -368,6 +372,7 @@ update ci cm = MkConfig {
   , logLevel     = fromMaybe ci.logLevel cm.logLevel
   , codegen      = fromMaybe ci.codegen cm.codegen
   , output       = fromMaybe ci.output cm.output
+  , levels       = mergeWith (\_,v => v) ci.levels (fromMaybe empty cm.levels)
   }
 
 --------------------------------------------------------------------------------

--- a/src/Pack/Core/TOML.idr
+++ b/src/Pack/Core/TOML.idr
@@ -28,6 +28,9 @@ TOMLKey DBName where
 export
 TOMLKey PkgName where fromKey = Right . MkPkgName
 
+export
+TOMLKey String where fromKey = Right
+
 ||| Interface for converting a TOML value to a pack
 ||| data type. We pass the TOML file's absolute path
 ||| as an additional argument, since this allows us to
@@ -163,6 +166,14 @@ toRelFile _                     = Left (WrongType [] "relative file path")
 
 export %inline
 FromTOML (Path Rel) where fromTOML = trefine toRelPath
+
+toLogLevel : String -> Either TOMLErr LogLevel
+toLogLevel s = case lookup s logLevels of
+  Just lvl => Right lvl
+  Nothing  => Left (WrongType [] "log level")
+
+export %inline
+FromTOML LogLevel where fromTOML = trefine toLogLevel
 
 export %inline
 FromTOML (File Rel) where fromTOML = trefine toRelFile

--- a/src/Pack/Runner.idr
+++ b/src/Pack/Runner.idr
@@ -35,7 +35,7 @@ Command Cmd where
   defaultLevel Remove           = Build
   defaultLevel RemoveApp        = Build
   defaultLevel Run              = Warning
-  defaultLevel Test             = Build
+  defaultLevel Test             = Warning
   defaultLevel Update           = Build
   defaultLevel Fetch            = Build
   defaultLevel PackagePath      = Silence


### PR DESCRIPTION
A short discussion on discord showed that pack users have different preferences about what log level to use as a default for different commands. This PR adds support for specifying the default log level for each command in the `pack.toml` file. In addition, the default log level for the `test` command is changed to `Warning` to be consistent with the default levels of `run` and `exec`.

The following syntax is supported:

```toml
[log]
exec = "build"
test  = "warning"
```