### PR TITLE
[ admin ] uncache library after creating docs

### DIFF
--- a/src/Pack/Runner/Install.idr
+++ b/src/Pack/Runner/Install.idr
@@ -321,6 +321,7 @@ installDocs rl = case rl.status of
     let docs := pkgDocs rl.name rl.pkg
     when !(exists docs) (rmDir docs)
     copyDir docsDir docs
+    uncacheLib (name rl)
 
 katla : (c : Config) => List (InstallType, PkgName)
 katla = if c.withDocs && c.useKatla then [(App False, "katla")] else []


### PR DESCRIPTION
This fixes the same issue as #225 but for generating api docs: We need to remove those libraries from the cache of resolved libs, which we installed or for which we built api-docs during collection checking with `pack-admin`, otherwise, those libs get recompiled again and again when they are used as dependencies by other packages. This PR fixes this for docs generation.