### PR TITLE
Rename the `pack query modules` option to `pack query module`

### DIFF
--- a/src/Pack/CmdLn/Types.idr
+++ b/src/Pack/CmdLn/Types.idr
@@ -24,7 +24,7 @@ Arg PkgQuery where
   argDesc_ = "[mode] <query>"
 
   readArg ("dep" :: s :: t)     = Just (MkQ Dependency s, t)
-  readArg ("modules" :: s :: t) = Just (MkQ Module s, t)
+  readArg ("module" :: s :: t) = Just (MkQ Module s, t)
   readArg [s]                   = Just (MkQ PkgName s, [])
   readArg _                     = Nothing
 

--- a/src/Pack/CmdLn/Types.idr
+++ b/src/Pack/CmdLn/Types.idr
@@ -23,10 +23,10 @@ export
 Arg PkgQuery where
   argDesc_ = "[mode] <query>"
 
-  readArg ("dep" :: s :: t)     = Just (MkQ Dependency s, t)
+  readArg ("dep" :: s :: t)    = Just (MkQ Dependency s, t)
   readArg ("module" :: s :: t) = Just (MkQ Module s, t)
-  readArg [s]                   = Just (MkQ PkgName s, [])
-  readArg _                     = Nothing
+  readArg [s]                  = Just (MkQ PkgName s, [])
+  readArg _                    = Nothing
 
 public export
 record FuzzyQuery where


### PR DESCRIPTION
Currently pack's CLI help options say this is what it should be
`pack help query`:
>  * `module` : Search a package by its modules. For
      instance, `pack query module Data.List` will list all packages,
      which export module `Data.List`. Only exact matches will
      be listed.

Additionally this name makes more sense to me, as pack only queries for a single string

This is a breaking change, although `pack query` is generally used manually, so changing it shouldn't be a problem.