### PR TITLE
[ new ] pretty-printed dependency graphs

### DIFF
--- a/pack.ipkg
+++ b/pack.ipkg
@@ -40,6 +40,7 @@ modules = Pack.CmdLn
 
         , Pack.Database
         , Pack.Database.TOML
+        , Pack.Database.Tree
         , Pack.Database.Types
 
         , Pack.Runner

--- a/src/Pack/Admin/Report/Types.idr
+++ b/src/Pack/Admin/Report/Types.idr
@@ -169,4 +169,3 @@ export
 resolveLine : Report -> Maybe String
 resolveLine (Error x y) = Just "\{x}"
 resolveLine _           = Nothing
-

--- a/src/Pack/CmdLn/Completion.idr
+++ b/src/Pack/CmdLn/Completion.idr
@@ -47,7 +47,7 @@ packagesOrIpkg = do
 all : HasIO io => Env => io (List QPkg)
 all = do
   ei <- runEitherT $ resolveAll
-  pure $ either (const []) id ei
+  pure $ either (const []) snd ei
 
 -- Lists only installed packages
 installedLibs : HasIO io => Env => io (List String)

--- a/src/Pack/CmdLn/Opts.idr
+++ b/src/Pack/CmdLn/Opts.idr
@@ -104,7 +104,7 @@ descs = [ MkOpt ['p'] ["package-set"]   (ReqArg setDB "<db>")
             "Print a detailed description of a package known to pack"
         , MkOpt [] ["tree"]   (NoArg $ setQuery Tree)
             "Print a dependency tree of a package known to pack"
-        , MkOpt [] ["parent-tree"]   (NoArg $ setQuery ParentTree)
+        , MkOpt [] ["reverse-tree"]   (NoArg $ setQuery ReverseTree)
             """
             Print a tree of packages depending on a package know to pack
             Use this to find all packages transitively depending on a specific

--- a/src/Pack/CmdLn/Opts.idr
+++ b/src/Pack/CmdLn/Opts.idr
@@ -102,6 +102,14 @@ descs = [ MkOpt ['p'] ["package-set"]   (ReqArg setDB "<db>")
             """
         , MkOpt ['l'] ["long-desc"]   (NoArg $ setQuery Details)
             "Print a detailed description of a package known to pack"
+        , MkOpt [] ["tree"]   (NoArg $ setQuery Tree)
+            "Print a dependency tree of a package known to pack"
+        , MkOpt [] ["parent-tree"]   (NoArg $ setQuery ParentTree)
+            """
+            Print a tree of packages depending on a package know to pack
+            Use this to find all packages transitively depending on a specific
+            library
+            """
         , MkOpt ['d'] ["dependencies"]   (NoArg $ setQuery Dependencies)
             "Print the dependencies of each query result."
         , MkOpt ['o'] ["output"]   (ReqArg  setOutput "<file>")

--- a/src/Pack/CmdLn/Opts.idr
+++ b/src/Pack/CmdLn/Opts.idr
@@ -106,7 +106,7 @@ descs = [ MkOpt ['p'] ["package-set"]   (ReqArg setDB "<db>")
             "Print a dependency tree of a package known to pack"
         , MkOpt [] ["reverse-tree"]   (NoArg $ setQuery ReverseTree)
             """
-            Print a tree of packages depending on a package know to pack
+            Print a tree of packages depending on a package know to pack.
             Use this to find all packages transitively depending on a specific
             library
             """

--- a/src/Pack/Config/Types.idr
+++ b/src/Pack/Config/Types.idr
@@ -59,7 +59,7 @@ data QueryType : Type where
 
   ||| Print inverse dependency tree
   ||| (That is, a tree of packages depending on a given package)
-  ParentTree   : QueryType
+  ReverseTree  : QueryType
 
 ||| Code generator to use
 public export

--- a/src/Pack/Config/Types.idr
+++ b/src/Pack/Config/Types.idr
@@ -54,6 +54,13 @@ data QueryType : Type where
   ||| List detailed information about a package
   Details      : QueryType
 
+  ||| Print dependency tree
+  Tree         : QueryType
+
+  ||| Print inverse dependency tree
+  ||| (That is, a tree of packages depending on a given package)
+  ParentTree   : QueryType
+
 ||| Code generator to use
 public export
 data Codegen : Type where

--- a/src/Pack/Database/Tree.idr
+++ b/src/Pack/Database/Tree.idr
@@ -1,0 +1,128 @@
+module Pack.Database.Tree
+
+import Control.Monad.State
+import Data.Maybe
+import Data.List
+import Data.Nat
+import Data.SortedMap
+import Idris.Package.Types
+import Pack.Core.Types
+import Pack.Database.Types
+
+%default covering
+
+--------------------------------------------------------------------------------
+--         Graphs
+--------------------------------------------------------------------------------
+
+||| A dependency graph
+public export
+0 Graph : Type -> Type
+Graph a = SortedMap a (List a)
+
+||| Returns the graph with all edges inverted
+export
+invertGraph : Ord a => Graph a -> Graph a
+invertGraph = foldl add empty . SortedMap.toList
+  where
+    ins : a -> Graph a -> a -> Graph a
+    ins v g k = case lookup k g of
+      Nothing => insert k [v] g
+      Just vs => insert k (v::vs) g
+
+    add : Graph a -> (a,List a) -> Graph a
+    add g (k,vs) = foldl (ins k) g vs
+
+export
+dependencyGraph : SortedMap PkgName (ResolvedLib t) -> Graph PkgName
+dependencyGraph = map dependencies
+
+--------------------------------------------------------------------------------
+--         Trees
+--------------------------------------------------------------------------------
+
+public export
+record Tree a where
+  constructor T
+  label : a
+  deps  : List (Tree a)
+
+export
+Functor Tree where
+  map f (T l ds) = T (f l) (map f <$> ds)
+
+export
+filter : (a -> Bool) -> Tree a -> Maybe (Tree a)
+filter f (T l ds) =
+   if f l then Just $ T l (mapMaybe (filter f) ds) else Nothing
+
+public export
+0 TreeMap : Type -> Type
+TreeMap a = SortedMap a (Tree a)
+
+0 TreeST : Type -> Type -> Type
+TreeST a t = State (TreeMap a) t
+
+tree : Ord a => Graph a -> a -> TreeST a (Tree a)
+tree g k = do
+  Nothing <- lookup k <$> get | Just t => pure t
+  ts      <- traverse (tree g) (maybe [] id $ lookup k g)
+  modify (insert k $ T k ts)
+  pure $ T k ts
+
+export
+treeMap : Ord a => Graph a -> TreeMap a
+treeMap g = execState empty $ traverse_ (ignore . tree g) (keys g)
+
+export %inline
+childMap : SortedMap PkgName (ResolvedLib t) -> TreeMap PkgName
+childMap = treeMap . dependencyGraph
+
+export %inline
+parentMap : SortedMap PkgName (ResolvedLib t) -> TreeMap PkgName
+parentMap = treeMap . invertGraph . dependencyGraph
+
+export
+treeLookup : Ord a => a -> TreeMap a -> Tree a
+treeLookup v = fromMaybe (T v []) . lookup v
+
+--------------------------------------------------------------------------------
+--          Pretty-printing Tree
+--------------------------------------------------------------------------------
+
+merge1 :
+     SnocList (String,String)
+  -> Nat
+  -> List String
+  -> List String
+  -> (Nat,List String)
+merge1 sp n (x::xs) (y::ys) = merge1 (sp :< (x,y)) (max n (length x)) xs ys
+merge1 sp n xs      _       =
+  (S n, map (\(x,y) => padRight (S n) ' ' x ++ y) sp <>> xs)
+
+header : Nat -> String
+header m = "|" ++ replicate (pred m) '_'
+
+merge :
+     Nat
+  -> List String
+  -> List (List String)
+  -> (List String, Nat)
+merge m ss []      = (ss,m)
+merge m ss (x::xs) = let (n,ss2) := merge1 [<] 0 ss x in merge n ss2 xs
+
+treeLines : Interpolation a => Tree a -> (Nat, List String)
+treeLines (T l ds) =
+  let s       := interpolate l
+      lls     := map (("|" ::) . snd)
+               . reverse
+               . sortBy (comparing fst)
+               $ map treeLines ds
+
+      (h::t)  := lls | [] => (1, [s])
+      (ls,os) := merge 0 h t
+      in (length ls + 2, s :: header os :: ls)
+
+export %inline
+prettyTree : Interpolation a => Tree a -> String
+prettyTree = unlines . snd . treeLines

--- a/src/Pack/Database/Types.idr
+++ b/src/Pack/Database/Types.idr
@@ -286,7 +286,7 @@ record ResolvedLib t where
   status  : PkgStatus pkg
   deps    : List (DPair Package PkgStatus)
 
-namespace ResolveLib
+namespace ResolvedLib
   ||| Extracts the package name from a resolved library.
   export %inline
   nameStr : ResolvedLib t -> String

--- a/src/Pack/Runner/Develop.idr
+++ b/src/Pack/Runner/Develop.idr
@@ -46,7 +46,7 @@ replDeps Nothing  NoPkgs         = pure $ []
 replDeps Nothing  AutoLibs       = pure $ e.env.config.autoLibs
 replDeps Nothing  (AutoPkgs ps)  = pure $ ps
 replDeps Nothing  Installed      =
-  map name . filter installedLib <$> resolveAll
+  map name . filter installedLib . snd <$> resolveAll
 
 covering
 replOpts :  HasIO io

--- a/src/Pack/Runner/Query.idr
+++ b/src/Pack/Runner/Query.idr
@@ -10,6 +10,7 @@ import Pack.CmdLn.Types
 import Pack.Config
 import Pack.Core
 import Pack.Database
+import Pack.Database.Tree
 import Pack.Runner.Database
 import Pack.Runner.Install
 import Pack.Version
@@ -76,8 +77,15 @@ pkgNames : Env => List PkgName
 pkgNames = keys allPackages
 
 export covering
-resolveAll : HasIO io => Env => EitherT PackErr io (List QPkg)
-resolveAll = traverse resolve pkgNames
+resolveAll :
+     {auto h : HasIO io}
+  -> {auto env : Env}
+  -> EitherT PackErr io (SortedMap PkgName (ResolvedLib U), List QPkg)
+resolveAll = do
+  ps <- traverse resolve pkgNames
+  sm <- readIORef env.cache
+  pure (sm, ps)
+
 
 --------------------------------------------------------------------------------
 --         Queries
@@ -86,9 +94,16 @@ resolveAll = traverse resolve pkgNames
 covering
 query_ :  HasIO io
        => Env
-       => (q : QPkg -> Maybe b)
+       => (q : (parents,children : Tree PkgName) -> QPkg -> Maybe b)
        -> EitherT PackErr io (List b)
-query_ q = mapMaybe q <$> resolveAll
+query_ q = do
+  (sm,ps) <- resolveAll
+
+  let children := childMap sm
+
+      parents  := parentMap sm
+
+  pure $ mapMaybe (\p => q (treeLookup (name p) parents) (treeLookup (name p) children) p) ps
 
 shortDesc : QPkg -> Maybe String
 shortDesc q = q.lib.desc.desc.brief
@@ -161,9 +176,16 @@ keep PkgName    q p = isInfixOf q (nameStr p)
 keep Dependency q p = any ((q ==) . value) (dependencies p)
 keep Module     q p = any (isInfixOf q . show . fst) (modules p.lib.desc.desc)
 
-resultString : (c : Config) => (query : String) -> QueryMode -> QPkg -> String
-resultString q Module qp = namePlusModules q qp
-resultString _ _      qp = case c.queryType of
+covering
+resultString :
+     {auto e : Env}
+  -> (query : String)
+  -> QueryMode
+  -> (parents, children : Tree PkgName)
+  -> QPkg
+  -> String
+resultString q Module _  _  qp = namePlusModules q qp
+resultString _ _      ps cs qp = case e.config.queryType of
   NameOnly => nameStr qp
 
   ShortDesc =>
@@ -184,6 +206,14 @@ resultString _ _      qp = case c.queryType of
 
   Ipkg => unlines $ nameStr qp :: map (indent 2) (lines qp.lib.desc.cont)
 
+  Tree => case filter ("base" /=) cs of
+    Just tr' => prettyTree tr'
+    Nothing  => prettyTree cs
+
+  ParentTree => case filter ("base" /=) ps of
+    Just tr' => prettyTree tr'
+    Nothing  => prettyTree ps
+
 export covering
 query :  HasIO io
       => QueryMode
@@ -191,7 +221,7 @@ query :  HasIO io
       -> Env
       -> EitherT PackErr io ()
 query m n e = do
-  ss <- query_ $ \p => toMaybe (keep m n p) (resultString n m p)
+  ss <- query_ $ \ps,cs,p => toMaybe (keep m n p) (resultString n m ps cs p)
   putStrLn $ unlines ss
 
 --------------------------------------------------------------------------------
@@ -239,7 +269,7 @@ infoString ps = """
 
 export covering
 printInfo : HasIO io => Env -> EitherT PackErr io ()
-printInfo e = resolveAll >>= putStrLn . infoString
+printInfo e = resolveAll >>= putStrLn . infoString . snd
 
 --------------------------------------------------------------------------------
 --          Fuzzy Search
@@ -251,7 +281,7 @@ installedPkgs :  HasIO io
               => List PkgName
               -> EitherT PackErr io (List QPkg, List QPkg)
 installedPkgs ns = do
-  all <- filter installedLib <$> resolveAll
+  all <- filter installedLib . snd <$> resolveAll
   pure (all, filter inPkgs all)
   where inPkgs : QPkg -> Bool
         inPkgs qp = isNil ns || elem (name qp) ns

--- a/src/Pack/Runner/Query.idr
+++ b/src/Pack/Runner/Query.idr
@@ -207,12 +207,12 @@ resultString _ _      ps cs qp = case e.config.queryType of
   Ipkg => unlines $ nameStr qp :: map (indent 2) (lines qp.lib.desc.cont)
 
   Tree => case filter ("base" /=) cs of
-    Just tr' => prettyTree tr'
-    Nothing  => prettyTree cs
+    Just tr' => prettyTree False tr'
+    Nothing  => prettyTree False cs
 
-  ParentTree => case filter ("base" /=) ps of
-    Just tr' => prettyTreeRev tr'
-    Nothing  => prettyTreeRev ps
+  ReverseTree => case filter ("base" /=) ps of
+    Just tr' => prettyTree True tr'
+    Nothing  => prettyTree True ps
 
 export covering
 query :  HasIO io

--- a/src/Pack/Runner/Query.idr
+++ b/src/Pack/Runner/Query.idr
@@ -211,8 +211,8 @@ resultString _ _      ps cs qp = case e.config.queryType of
     Nothing  => prettyTree cs
 
   ParentTree => case filter ("base" /=) ps of
-    Just tr' => prettyTree tr'
-    Nothing  => prettyTree ps
+    Just tr' => prettyTreeRev tr'
+    Nothing  => prettyTreeRev ps
 
 export covering
 query :  HasIO io


### PR DESCRIPTION
Adds query options `-tree` and `--parent-tree`. The former prints the dependency graph of a library, the latter the inverse dependency graph: A tree of libraries (transitively) depending on the one we are searching.

Examples:

```sh
» build/exec/pack --tree query rhone
rhone
|
|
quantifiers-extra

rhone-js
|______________________________
|            |                 |
dom          refined           rhone
|__          |_______          |
|  |         |       |         |
js elab-util algebra elab-util quantifiers-extra
|_________________
|                 |
quantifiers-extra elab-util
```