### PR TITLE
Install idris2 with racket

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -57,7 +57,11 @@ if [ -d "/opt/homebrew/include" ]; then
 fi
 
 check_installed git
-check_installed "$SCHEME"
+if [ -z "DETECTED_RACKET" ]; then
+  check_installed "$SCHEME"
+else
+  check_installed racket
+fi
 check_installed make
 
 # Install package collection

--- a/install.bash
+++ b/install.bash
@@ -17,23 +17,30 @@ function check_installed {
 
 PACK_DIR="${PACK_DIR:-$HOME/.pack}"
 
+DETECTED_RACKET=''
+DETECTED_SCHEME=''
+
 if command -v chezscheme &>/dev/null; then
 	DETECTED_SCHEME=chezscheme
 elif command -v scheme &>/dev/null; then
 	DETECTED_SCHEME=scheme
 elif command -v chez &>/dev/null; then
 	DETECTED_SCHEME=chez
-else
-	DETECTED_SCHEME=''
+elif command -v racket &>/dev/null; then
+	DETECTED_RACKET=racket
 fi
 
-read -r -p "Enter the name of your chez scheme binary [$DETECTED_SCHEME]: " SCHEME
-SCHEME=${SCHEME:-$DETECTED_SCHEME}
+if [ -z "$DETECTED_SCHEME$DETECTED_RACKET" ]; then
+	read -r -p "Enter the name of your chez scheme binary [$DETECTED_SCHEME]: " SCHEME
+	SCHEME=${SCHEME:-$DETECTED_SCHEME}
+else
+	SCHEME=''
+fi
 
 # Verify that the necessary programs are installed
 
-if [ -z "$SCHEME" ]; then
-	echo 'scheme binary was not set'
+if [ -z "$SCHEME$DETECTED_RACKET" ]; then
+	echo 'scheme or racket binary was not set'
 	exit 1
 fi
 
@@ -75,7 +82,11 @@ git checkout "$IDRIS2_COMMIT"
 PREFIX_PATH="$PACK_DIR/install/$IDRIS2_COMMIT/idris2"
 BOOT_PATH="$PACK_DIR/install/$IDRIS2_COMMIT/idris2/bin/idris2"
 
-make bootstrap PREFIX="$PREFIX_PATH" SCHEME="$SCHEME"
+if [ -z "$SCHEME" ]; then
+	make bootstrap-racket PREFIX="$PREFIX_PATH"
+else
+	make bootstrap PREFIX="$PREFIX_PATH" SCHEME="$SCHEME"
+fi
 make install PREFIX="$PREFIX_PATH"
 make clean
 make all IDRIS2_BOOT="$BOOT_PATH" PREFIX="$PREFIX_PATH"


### PR DESCRIPTION
This changes tries to detect racket binary, and make it as a fallback to build idris2 if no chez scheme