### PR TITLE
Update documentation of the `new` command and add an example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To create a new library project, type
 pack new lib idris2-library
 ```
 replacing `idris2-library` with the name of your library.
-This will create a new package in the current directory consisting of a source directory, default module, a skeleton test and a .ipkg file.
+This will create a new package in the current directory consisting of a source directory, a default module, a skeleton test suite, a local pack.toml file and a .ipkg file.
 A git repository will also be initialized together with a suitable `.gitignore` file.
 If you wish to create a new application project, replace `lib` with `app`.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ pack help
 In the following sections, we assume the `$PACK_DIR/bin` folder
 is on your path and you have installed
 pack as described under [installation](INSTALL.md).
+
+To create a new library project, type
+
+```sh
+pack new lib idris2-library
+```
+replacing `idris2-library` with the name of your library.
+This will create a new package in the current directory consisting of a source directory, default module, a skeleton test and a .ipkg file.
+A git repository will also be initialized together with a suitable `.gitignore` file.
+If you wish to create a new application project, replace `lib` with `app`.
+
 To install a library from the package collection, run
 
 ```sh

--- a/src/Pack/CmdLn/Types.idr
+++ b/src/Pack/CmdLn/Types.idr
@@ -247,7 +247,7 @@ cmdDesc Test              = """
 
 cmdDesc New              = """
   Create a new package in the current directory
-  consisting of a source directory, default module and a .ipkg file.
+  consisting of a source directory, a default module, a skeleton test suite, a local pack.toml file and a .ipkg file.
   A git repository will also be initialized together with a
   suitable `.gitignore` file.
 


### PR DESCRIPTION
This is following the merge of pull request #213 which creates a skeleton test suite and a `pack.toml` file and to be in line with the wish to have commands documented in the README file.

As it is a basic command, my belief is that it would be helpful for new users to have it documented in the README (although you could argue that the function is already pretty well documented with the `pack help` command and I would agree!).