### PR TITLE
[ gc ] Make `gc` command to not to clean up too much

### DIFF
--- a/example1/README.md
+++ b/example1/README.md
@@ -102,7 +102,7 @@ or the Idris ide-mode when coding in Idris. While pack can
 make its managed packages available to these tools (for instance,
 if you use *idris2-lsp*, you can conveniently install it via
 pack and it will automatically have access to all libraries
-installed by pack: `pack install-app lsp`), these tools will typically
+installed by pack: `pack install-app idris2-lsp`), these tools will typically
 not install or update any required dependencies automatically.
 In this case it is necessary to first run `pack install-deps my.ipkg`
 before you start coding on a project.

--- a/src/Pack/Config/Environment.idr
+++ b/src/Pack/Config/Environment.idr
@@ -648,8 +648,11 @@ env mc fetch = do
 
   let url    := fromMaybe db.idrisURL c.idrisURL
       commit := fromMaybe db.idrisCommit c.idrisCommit
+      -- take the DB's idris commit into account
+      c'     := {allIdrisCommits $= (db.idrisCommit ::)} c
       -- adjust the idrisCommit and URL to use according to user overrides
-      env    := MkEnv pd td c ch ({idrisURL := url, idrisCommit := commit} db) lbf
+      db'    := {idrisURL := url, idrisCommit := commit} db
+      env    := MkEnv pd td c' ch db' lbf
 
   cachePkgs $> env
 

--- a/src/Pack/Config/TOML.idr
+++ b/src/Pack/Config/TOML.idr
@@ -103,7 +103,7 @@ initToml scheme db = """
   # List of packages and apps with custom build hooks we trust to
   # be safe. This gives more fine grained control over package safety
   # than `safety-prompt`.
-  whitelist = [ "pack", "lsp" ]
+  whitelist = [ "pack", "idris2-lsp" ]
 
   # Must-have libraries. These will be installed automatically
   # when using a new package collection.
@@ -111,7 +111,7 @@ initToml scheme db = """
 
   # Must-have applications. These will be installed automatically
   # when using a new package collection.
-  # apps       = [ "lsp" ]
+  # apps       = [ "idris2-lsp" ]
 
   [pack]
 

--- a/src/Pack/Config/TOML.idr
+++ b/src/Pack/Config/TOML.idr
@@ -40,6 +40,7 @@ FromTOML UserConfig where
           (maybeValAt "collection" f v)
           (maybeValAt "idris2.url" f v)
           (maybeValAt "idris2.commit" f v)
+          (toList <$> maybeValAt "idris2.commit" f v)
           (maybeValAt "pack.url" f v)
           (maybeValAt "pack.commit" f v)
           (maybeValAt "idris2.scheme" f v)

--- a/src/Pack/Runner/Database.idr
+++ b/src/Pack/Runner/Database.idr
@@ -352,7 +352,7 @@ checkDeletable ns = do
 idrisDelDir : (e : Env) => Body -> Maybe (Path Abs)
 idrisDelDir b =
   let s := interpolate b
-   in toMaybe (s /= "pack" && s /= e.db.idrisCommit.value) (installDir /> b)
+   in toMaybe (s /= "pack" && all (\ic => s /= ic.value) e.config.allIdrisCommits) (installDir /> b)
 
 packDelDir : (e : Env) => Body -> Maybe (Path Abs)
 packDelDir b =


### PR DESCRIPTION
If we have local `pack.toml`s with alternative Idris commits set, currently `pack gc` will clean up all but only those in the localmost `pack.toml`, including the version from the current pack collection. This commit fixes it, `pack gc` now does not clean up an Idris commit mentioned in the current pack collection and in all local `pack.toml`s all way up. It fixes #246.

NB: if alternative Idris commit is not set in any local `pack.toml`s, the behaviour of `pack gc` should not change.

Additonally, this PR has a small commit with changes not worth a separate PR.