### PR TITLE
[ fix ] example apps list in install script

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -166,7 +166,7 @@ safety-prompt = true
 
 # Must-have applications. These will be installed automatically
 # when using a new package collection.
-# apps       = [ "lsp" ]
+# apps       = [ "idris2-lsp" ]
 
 [idris2]
 


### PR DESCRIPTION
As mentioned on discord, in the `pack.toml` file copied from the installation bash script, the (commented-out) list of apps to be installed automatically still contains the old name of the `idris2-lsp` application. This is fixed with this PR.