### PR TITLE
[ bump ] Update deprecated CI actions and use newer linter version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
+#max_line_length = 80
 
 # Idris source files
 [*.{idr,ipkg,tex,yaff,lidr}]
@@ -49,6 +50,7 @@ indent_size = 2
 
 [expected]
 trim_trailing_whitespace = false
+max_line_length = off
 
 # Ignore paths
 [/micropack/*]

--- a/.github/workflows/ci-lib.yml
+++ b/.github/workflows/ci-lib.yml
@@ -1,3 +1,4 @@
+---
 name: Build
 
 on:
@@ -12,6 +13,8 @@ on:
   schedule:
     - cron: '0 21 * * *'
 
+permissions: read-all
+
 defaults:
   run:
     shell: bash
@@ -24,21 +27,21 @@ jobs:
     container: snazzybucket/idris2api:latest
     steps:
       - name: Checkout toml-idr
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: cuddlefishie/toml-idr
       - name: Download already installed dependencies
         uses: actions/download-artifact@master
         with:
-          name: dependencies-for-latest
           path: /root/.idris2/
+          merge-multiple: true
         continue-on-error: true
       - name: Install toml-idr
         run: make install
       - name: Save installed lib
         uses: actions/upload-artifact@master
         with:
-          name: dependencies-for-latest
+          name: built-toml
           path: /root/.idris2/idris2-*/toml*
           if-no-files-found: error
 
@@ -48,21 +51,21 @@ jobs:
     container: snazzybucket/idris2api:latest
     steps:
       - name: Checkout filepath
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: stefan-hoeck/idris2-filepath
       - name: Download already installed dependencies
         uses: actions/download-artifact@master
         with:
-          name: dependencies-for-latest
           path: /root/.idris2/
+          merge-multiple: true
         continue-on-error: true
       - name: Install filepath
         run: idris2 --install filepath.ipkg
       - name: Save installed lib
         uses: actions/upload-artifact@master
         with:
-          name: dependencies-for-latest
+          name: built-filepath
           path: /root/.idris2/idris2-*/filepath*
           if-no-files-found: error
 
@@ -74,13 +77,14 @@ jobs:
     runs-on: ubuntu-latest
     container: snazzybucket/idris2api:latest
     steps:
+
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Download installed dependencies
         uses: actions/download-artifact@master
         with:
-          name: dependencies-for-latest
           path: /root/.idris2/
+          merge-multiple: true
       - name: Install git
         run: |
           apt-get update
@@ -95,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install scheme
         run: |
           sudo apt-get update
@@ -118,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install scheme
         run: |
           sudo apt-get update
@@ -141,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install scheme
         run: |
           sudo apt-get update
@@ -164,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install scheme
         run: |
           sudo apt-get update

--- a/.github/workflows/ci-super-linter.yml
+++ b/.github/workflows/ci-super-linter.yml
@@ -1,3 +1,4 @@
+---
 name: Lint
 
 on:
@@ -11,6 +12,9 @@ on:
       - main
       - master
 
+permissions:
+  statuses: write
+
 jobs:
   build:
     name: Lint Code Base
@@ -18,15 +22,15 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
-          # Full git history is needed to get a proper list of changed files within `super-linter`
+          # Full git history is needed to get a proper
+          # list of changed files within `super-linter`
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter/slim@v4.8.5
+        uses: super-linter/super-linter/slim@v6.0.0
         env:
-          VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IGNORE_GENERATED_FILES: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,7 @@
+---
 name: Docker Build
+
+permissions: read-all
 
 on:
   pull_request:
@@ -17,7 +20,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v4
 
       - name: Get date for DB version
         run: |

--- a/.github/workflows/notify-on-fail.yml
+++ b/.github/workflows/notify-on-fail.yml
@@ -1,6 +1,8 @@
 ---
 name: Notify if build fails
 
+permissions: read-all
+
 on:
   workflow_run:
     workflows:


### PR DESCRIPTION
This is a technical stuff, originated by deprecation warnings shown by GitHub Actions and breaking changes in the upstream actions behaviour

EDIT: current problems are in liniting of the Dockerfile. Both problems are reasonable, but the first one maybe should be suppressed, since doing things properly will break everyone's usage of the pack's docker image for those who set `PACK_DIR` to `/root/.pack` manually.

EDIT2: ...but doing things properly will make transition from other's idris-containing images to the pack one seamless, without a need to reser the variable

EDIT3: maybe, we can make a proper user, and just add a symlink of `/root/.pack` to `/home/<pack-user>/.pack` for the seamless backwards compatibility. Also, setting `PACK_DIR` in the docker file seems to be a good idea, to not to make users to do the same thing again and again.