### PR TITLE
[ lint ] Make Dockerfile pass the linter & expose `PACK_DIR` variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+#checkov:skip=CKV_DOCKER_3: we intend to use `root` user
+
 FROM ubuntu:22.04 AS build
 
 SHELL ["/bin/bash", "-c"]
@@ -29,6 +31,9 @@ RUN apt-get update && apt-get install --yes gcc make chezscheme libgmp3-dev git 
 SHELL ["/bin/bash", "-c"]
 
 ENV HOME="/root"
+ENV PACK_DIR="$HOME/.pack"
 
-ENV PATH "/root/.pack/bin:$PATH"
-COPY --from=build $HOME/.pack $HOME/.pack
+ENV PATH "$PACK_DIR/bin:$PATH"
+COPY --from=build $PACK_DIR $PACK_DIR
+
+HEALTHCHECK CMD idris2 --version || exit 1


### PR DESCRIPTION
`PACK_DIR` exposure is a backwards-compatible change since it anyway had to be set by the user with this particular value.