### PR TITLE
[ re #276 ] Make docker healthcheck to be not side-effecting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ ENV PACK_DIR="$HOME/.pack"
 ENV PATH "$PACK_DIR/bin:$PATH"
 COPY --from=build $PACK_DIR $PACK_DIR
 
-HEALTHCHECK CMD idris2 --version || exit 1
+HEALTHCHECK CMD pack help || exit 1


### PR DESCRIPTION
I'm sorry, I didn't realise that in #276 I added a side-effecting call to `idris2` (which may change the state of `$HOME/.pack` in some circumstances), which made some operations failing in a flaky way when being run under the pack's docker image, e.g. when either two calls to `pack` are changing same files in a non-synchronised fashion, or another utilities, like `tar` are detecting changes in the file system, which are unexpected to them.

So, let's change the healthcheck command to a more appropriate one -- it checks that `pack` runs, but `help` command is not side-effecting.