### PR TITLE
Remove "Stuff still missing" section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,18 +287,3 @@ on several packages in parallel via git. Details can be found
 > and in the pack collection).
 > You can see an example of such usage [here](https://github.com/stefan-hoeck/idris2-pack-db/blob/bcc8dc61706c73361bb1e6e18dd1b0c5981f0e18/collections/HEAD.toml#L297).
 > Technical details can be found [here](https://github.com/stefan-hoeck/idris2-pack/issues/256#issuecomment-1689305587).
-
-## Stuff still Missing
-
-There is a lot of functionality still missing. Here's a
-non-comprehensive list:
-
-- [x] Support for local package collections
-- [x] Command for starting a REPL session
-- [x] Support for custom build directories
-- [x] Command for typechecking an Idris package
-- [x] Command for building a local Idris2 package
-- [x] Command for running an application
-- [x] Command for querying a data collection
-- [x] Command for listing current version of data collection
-- [x] Support for running tests


### PR DESCRIPTION
Seems this section is all implemented now, and as a reader it's unclear to me whether those things are still missing or were and have been completed