### PR TITLE
[ new ] Support searching the only `ipkg` when no package is given

### DIFF
--- a/src/Pack/CmdLn/Types.idr
+++ b/src/Pack/CmdLn/Types.idr
@@ -172,20 +172,24 @@ export
 cmdDesc : Cmd -> String
 cmdDesc Build            = """
   Build a local package given as an `.ipkg` file or package name.
+  When no package is given, try to find the only one in the current directory.
   This will also install the package's dependencies.
   """
 
 cmdDesc BuildDeps        = """
   Install the dependencies of a local package given as an `.ipkg` file
-  or package name.
+  or package name. When no package is given, try to find the only one
+  in the current directory.
   """
 
 cmdDesc Typecheck        = """
   Typecheck a local package given as an `.ipkg` file or package name.
+  When no package is given, try to find the only one in the current directory.
   """
 
 cmdDesc Clean            = """
   Clean up a local package by removing its build directory.
+  When no package is given, try to find the only one in the current directory.
   """
 
 cmdDesc CleanBuild       = """
@@ -229,6 +233,8 @@ cmdDesc RemoveApp        = "Uninstall the given applications."
 cmdDesc Run              = """
   Run an application from the package collection or a local `.ipkg`
   file passing it the given command line arguments.
+  When no package and no arguments are given, try to find the only one
+  in the current directory.
 
   Note: This will install remote apps before running them without
   generating an entry in `$PACK_DIR/bin`.

--- a/src/Pack/Core/Types.idr
+++ b/src/Pack/Core/Types.idr
@@ -752,7 +752,7 @@ data PackErr : Type where
 
   ||| Trying to run zero or more than one local package
   ||| (or something that isn't a local package).
-  BuildMany : PackErr
+  BuildMany : List Body -> PackErr
 
   ||| Unknown pack command
   UnknownCommand : String -> (usage : String) -> PackErr
@@ -886,8 +886,12 @@ printErr (InvalidCmdArgs cmd args usage) =
   \{usage}
   """
 
-printErr BuildMany =
-  "Can only build or typecheck a single Idris2 package given as an `.ipkg` file."
+printErr (BuildMany []) = "No local `.ipkg` files found."
+printErr (BuildMany fs@(_::_)) = """
+  Ambiguous `.ipkg` files:
+  \{joinBy "\n" $ ("- " ++) . interpolate <$> fs}
+  Please choose only one.
+  """
 
 printErr (NoFilePath s) = "Not a file path : \{s}"
 

--- a/src/Pack/Runner.idr
+++ b/src/Pack/Runner.idr
@@ -151,8 +151,7 @@ runCmd = do
       (Fuzzy ** [MkFQ m s])     => idrisEnv mc fetch >>= fuzzy m s
       (UpdateDB ** [])          => updateDB
       (CollectGarbage ** [])    => env mc fetch >>= garbageCollector
-      (Run ** [Pkg p,args])     => idrisEnv mc fetch >>= execApp p args
-      (Run ** [Ipkg p,args])    => idrisEnv mc fetch >>= runIpkg p args
+      (Run ** [p,args])         => idrisEnv mc fetch >>= runApp p args
       (Test ** [p,args])        => idrisEnv mc fetch >>= runTest p args
       (Exec ** [p,args])        => idrisEnv mc fetch >>= exec p args
       (Repl ** [p])             => idrisEnv mc fetch >>= idrisRepl p

--- a/src/Pack/Runner/Database.idr
+++ b/src/Pack/Runner/Database.idr
@@ -114,6 +114,26 @@ findAndParseLocalIpkg (Pkg n)  =
     Just (Local dir ipkg _ _) => let p = dir </> ipkg in parseLibIpkg p p
     Just _                    => throwE (NotLocalPkg n)
 
+||| Looks at the current directory and tries to find the only `.ipkg` file,
+||| or fails with `AmbigIpkg` if it didn't manage to do so.
+findTheOnlyIpkg :
+     {auto _ : HasIO io}
+  -> {auto _ : CurDir}
+  -> EitherT PackErr io PkgOrIpkg
+findTheOnlyIpkg = do
+  [ipkg] <- filter isIpkgBody <$> entries curDir
+    | lfs => throwE (BuildMany lfs)
+  pure $ Ipkg $ curDir /> ipkg
+
+||| Returns present package, or else tries to find the only loca `.ipkg` file.
+export
+refinePkg :
+     {auto _ : HasIO io}
+  -> {auto _ : CurDir}
+  -> Maybe PkgOrIpkg
+  -> EitherT PackErr io PkgOrIpkg
+refinePkg (Just p) = pure p
+refinePkg Nothing  = findTheOnlyIpkg
 
 ||| Parse an `.ipkg` file representing an application
 ||| and check if it has no custom build hooks and does not produce

--- a/src/Pack/Runner/Develop.idr
+++ b/src/Pack/Runner/Develop.idr
@@ -210,3 +210,13 @@ execApp p args e = do
   case ipkgCodeGen ra.desc.desc of
     Node => sys $ ["node", pkgExec ra.name ra.pkg ra.exec] ++ args
     _    => sys $ [pkgExec ra.name ra.pkg ra.exec] ++ args
+
+export covering
+runApp :
+     {auto _ : HasIO io}
+  -> PkgOrIpkg
+  -> (args : CmdArgList)
+  -> IdrisEnv
+  -> EitherT PackErr io ()
+runApp (Pkg p)  = execApp p
+runApp (Ipkg p) = runIpkg p


### PR DESCRIPTION
I always lacked this (small) feature myself, but since I'm not the only one, I'd suppose to add it. Closes #297.

It is the most conservative solution: when no `ipkg` argument is given, it searches for the only available `ipkg` in the current directory and complains when was unable to find one or when there are too many of them.

It does **not** search in the upper directories when there is not `ipkg`s in the current one, and does not interact with any local `pack.toml` files during the search.

In case of additional arguments in the `run` command, since `Arg` parser for `Maybe` is greedy, we use this property to preserve the status quo behaviour: when anything is given after `pack run`, it is interpreted as the package name or package file. We are not trying to guess whether or not the first argument is a file or a program's parameter (and I think, it would be silly to do so, since program's argument can be a file anyway).