### PR TITLE
[ feature ] New Pack Command: Uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,3 +287,13 @@ on several packages in parallel via git. Details can be found
 > and in the pack collection).
 > You can see an example of such usage [here](https://github.com/stefan-hoeck/idris2-pack-db/blob/bcc8dc61706c73361bb1e6e18dd1b0c5981f0e18/collections/HEAD.toml#L297).
 > Technical details can be found [here](https://github.com/stefan-hoeck/idris2-pack/issues/256#issuecomment-1689305587).
+
+## Uninstallation
+
+If you would like to uninstall pack from your system, you can simply use the following command:
+
+```sh
+pack uninstall
+```
+
+This will delete the `$PACK_DIR` directory.

--- a/install.bash
+++ b/install.bash
@@ -43,7 +43,7 @@ fi
 
 if [ -d "$PACK_DIR" ]; then
 	echo "There is already a $PACK_DIR directory."
-	echo "Please remove it with 'rm -fr $PACK_DIR' and rerun this script."
+	echo "Please remove it with the 'pack uninstall' command and rerun this script."
 	exit 1
 fi
 

--- a/src/Pack/CmdLn/Completion.idr
+++ b/src/Pack/CmdLn/Completion.idr
@@ -138,8 +138,8 @@ opts x "switch"           = prefixOnlyIfNonEmpty x . ("latest" ::)
 opts x "clean"            = prefixOnlyIfNonEmpty x <$> ipkgFiles
 opts x "typecheck"        = prefixOnlyIfNonEmpty x <$> ipkgFiles
 opts x "new"              = prefixOnlyIfNonEmpty x <$> pure packageTypes
-opts x "help"             = prefixOnlyIfNonEmpty x <$> pure commands
 opts x "uninstall"        = pure Nil
+opts x "help"             = prefixOnlyIfNonEmpty x <$> pure commands
 
 -- options
 opts x _ = pure $

--- a/src/Pack/CmdLn/Completion.idr
+++ b/src/Pack/CmdLn/Completion.idr
@@ -139,6 +139,7 @@ opts x "clean"            = prefixOnlyIfNonEmpty x <$> ipkgFiles
 opts x "typecheck"        = prefixOnlyIfNonEmpty x <$> ipkgFiles
 opts x "new"              = prefixOnlyIfNonEmpty x <$> pure packageTypes
 opts x "help"             = prefixOnlyIfNonEmpty x <$> pure commands
+opts x "uninstall"        = pure Nil
 
 -- options
 opts x _ = pure $

--- a/src/Pack/CmdLn/Types.idr
+++ b/src/Pack/CmdLn/Types.idr
@@ -89,11 +89,11 @@ data Cmd : Type where
   Completion       : Cmd
   CompletionScript : Cmd
 
-  -- Help
-  PrintHelp        : Cmd
-
   -- Uninstall
   Uninstall        : Cmd
+
+  -- Help
+  PrintHelp        : Cmd
 
 ||| List of all available commands.
 |||
@@ -129,8 +129,8 @@ commands =
   , Fuzzy
   , Completion
   , CompletionScript
-  , PrintHelp
   , Uninstall
+  , PrintHelp
   ]
 
 ||| Name to use at the command-line for running a pack command
@@ -164,8 +164,8 @@ name Query            = "query"
 name Fuzzy            = "fuzzy"
 name Completion       = "completion"
 name CompletionScript = "completion-script"
-name PrintHelp        = "help"
 name Uninstall        = "uninstall"
+name PrintHelp        = "help"
 
 ||| List pairing a command with its name used for parsing commands.
 public export
@@ -392,6 +392,11 @@ cmdDesc CompletionScript = """
   for your shell.
   """
 
+cmdDesc Uninstall        = """
+  Uninstalls pack.
+  Deletes the $PACK_DIR directory.
+  """
+
 cmdDesc PrintHelp        = """
   Without an additional <cmd> argument, this prints general information
   about using pack, including a list of available command-line options
@@ -403,12 +408,6 @@ cmdDesc PrintHelp        = """
   Available commands:
   \{unlines $ map (indent 2 . fst) namesAndCommands}
   """
-
-cmdDesc Uninstall        = """
-  Uninstalls pack.
-
-  Deletes the $PACK_DIR directory.
-"""
 
 export
 Arg Cmd where
@@ -449,5 +448,5 @@ cmdInCommands Query            = %search
 cmdInCommands Fuzzy            = %search
 cmdInCommands Completion       = %search
 cmdInCommands CompletionScript = %search
-cmdInCommands PrintHelp        = %search
 cmdInCommands Uninstall        = %search
+cmdInCommands PrintHelp        = %search

--- a/src/Pack/CmdLn/Types.idr
+++ b/src/Pack/CmdLn/Types.idr
@@ -92,6 +92,9 @@ data Cmd : Type where
   -- Help
   PrintHelp        : Cmd
 
+  -- Uninstall
+  Uninstall        : Cmd
+
 ||| List of all available commands.
 |||
 ||| `Pack.CmdLn.Types.cmdInCommands` proofs that none was forgotten.
@@ -127,6 +130,7 @@ commands =
   , Completion
   , CompletionScript
   , PrintHelp
+  , Uninstall
   ]
 
 ||| Name to use at the command-line for running a pack command
@@ -161,6 +165,7 @@ name Fuzzy            = "fuzzy"
 name Completion       = "completion"
 name CompletionScript = "completion-script"
 name PrintHelp        = "help"
+name Uninstall        = "uninstall"
 
 ||| List pairing a command with its name used for parsing commands.
 public export
@@ -399,6 +404,12 @@ cmdDesc PrintHelp        = """
   \{unlines $ map (indent 2 . fst) namesAndCommands}
   """
 
+cmdDesc Uninstall        = """
+  Uninstalls pack.
+
+  Deletes the $PACK_DIR directory.
+"""
+
 export
 Arg Cmd where
   argDesc_ = "<cmd>"
@@ -439,3 +450,4 @@ cmdInCommands Fuzzy            = %search
 cmdInCommands Completion       = %search
 cmdInCommands CompletionScript = %search
 cmdInCommands PrintHelp        = %search
+cmdInCommands Uninstall        = %search

--- a/src/Pack/Runner.idr
+++ b/src/Pack/Runner.idr
@@ -53,8 +53,8 @@ Command Cmd where
   defaultLevel Fuzzy            = Cache
   defaultLevel Completion       = Silence
   defaultLevel CompletionScript = Silence
-  defaultLevel PrintHelp        = Silence
   defaultLevel Uninstall        = Info
+  defaultLevel PrintHelp        = Silence
 
   desc = cmdDesc
 
@@ -86,8 +86,8 @@ Command Cmd where
   ArgTypes Fuzzy            = [FuzzyQuery]
   ArgTypes Completion       = [String, String]
   ArgTypes CompletionScript = [String]
-  ArgTypes PrintHelp        = [Maybe Cmd]
   ArgTypes Uninstall        = []
+  ArgTypes PrintHelp        = [Maybe Cmd]
 
   readCommand_ n = lookup n namesAndCommands
 
@@ -130,8 +130,8 @@ Command Cmd where
   readArgs Fuzzy            = %search
   readArgs Completion       = %search
   readArgs CompletionScript = %search
-  readArgs PrintHelp        = %search
   readArgs Uninstall        = %search
+  readArgs PrintHelp        = %search
 
 isFetch : Cmd -> Bool
 isFetch Fetch = True

--- a/src/Pack/Runner.idr
+++ b/src/Pack/Runner.idr
@@ -13,6 +13,7 @@ import Pack.Runner.Develop
 import Pack.Runner.Query
 import Pack.Runner.Install
 import Pack.Runner.New
+import Pack.Runner.Uninstall
 
 public export
 Command Cmd where
@@ -53,6 +54,7 @@ Command Cmd where
   defaultLevel Completion       = Silence
   defaultLevel CompletionScript = Silence
   defaultLevel PrintHelp        = Silence
+  defaultLevel Uninstall        = Info
 
   desc = cmdDesc
 
@@ -85,6 +87,7 @@ Command Cmd where
   ArgTypes Completion       = [String, String]
   ArgTypes CompletionScript = [String]
   ArgTypes PrintHelp        = [Maybe Cmd]
+  ArgTypes Uninstall        = []
 
   readCommand_ n = lookup n namesAndCommands
 
@@ -128,6 +131,7 @@ Command Cmd where
   readArgs Completion       = %search
   readArgs CompletionScript = %search
   readArgs PrintHelp        = %search
+  readArgs Uninstall        = %search
 
 isFetch : Cmd -> Bool
 isFetch Fetch = True
@@ -179,3 +183,6 @@ runCmd = do
         env <- idrisEnv mc fetch
         install []
         writeCollection
+      (Uninstall ** [])         => do
+        env <- idrisEnv mc fetch
+        uninstallPack

--- a/src/Pack/Runner.idr
+++ b/src/Pack/Runner.idr
@@ -183,4 +183,4 @@ runCmd = do
         env <- idrisEnv mc fetch
         install []
         writeCollection
-      (Uninstall ** [])         => uninstallPack @{%search} @{metaConfigToLogRef @{mc}}
+      (Uninstall ** [])         => uninstallPack @{metaConfigToLogRef @{mc}}

--- a/src/Pack/Runner.idr
+++ b/src/Pack/Runner.idr
@@ -183,6 +183,4 @@ runCmd = do
         env <- idrisEnv mc fetch
         install []
         writeCollection
-      (Uninstall ** [])         => do
-        env <- idrisEnv mc fetch
-        uninstallPack
+      (Uninstall ** [])         => uninstallPack @{%search} @{metaConfigToLogRef @{mc}}

--- a/src/Pack/Runner/Uninstall.idr
+++ b/src/Pack/Runner/Uninstall.idr
@@ -1,7 +1,11 @@
 module Pack.Runner.Uninstall
 
-import Pack.Config
-import Pack.Core
+import Pack.Config.Types
+import Pack.Core.IO
+import Pack.Core.Logging
+import Pack.Core.Types
+
+%hide Pack.Config.Types.Env.packDir
 
 %default total
 
@@ -16,4 +20,7 @@ uninstallPack :
   -> EitherT PackErr io ()
 uninstallPack = do
   info "Uninstalling pack"
+  let msg := "$PACK_DIR: \{packDir}. Continue (yes/*no)?"
+  "yes" <- prompt Info msg
+    | _ => throwE SafetyAbort
   rmDir packDir

--- a/src/Pack/Runner/Uninstall.idr
+++ b/src/Pack/Runner/Uninstall.idr
@@ -16,7 +16,8 @@ import Pack.Core.Types
 export covering
 uninstallPack :
      {auto _ : HasIO io}
-  -> {auto _ : Env}
+  -> {auto _ : LogRef}
+  -> {auto _ : PackDir}
   -> EitherT PackErr io ()
 uninstallPack = do
   info "Uninstalling pack"

--- a/src/Pack/Runner/Uninstall.idr
+++ b/src/Pack/Runner/Uninstall.idr
@@ -21,7 +21,7 @@ uninstallPack :
   -> EitherT PackErr io ()
 uninstallPack = do
   info "Uninstalling pack"
-  let msg := "$PACK_DIR: \{packDir}. Continue (yes/*no)?"
+  let msg := "This command will delete the $PACK_DIR directory at \{packDir}. Continue (yes/*no)?"
   "yes" <- prompt Info msg
     | _ => throwE SafetyAbort
   rmDir packDir

--- a/src/Pack/Runner/Uninstall.idr
+++ b/src/Pack/Runner/Uninstall.idr
@@ -1,0 +1,19 @@
+module Pack.Runner.Uninstall
+
+import Pack.Config
+import Pack.Core
+
+%default total
+
+--------------------------------------------------------------------------------
+--          Uninstalling Pack
+--------------------------------------------------------------------------------
+
+export covering
+uninstallPack :
+     {auto _ : HasIO io}
+  -> {auto _ : Env}
+  -> EitherT PackErr io ()
+uninstallPack = do
+  info "Uninstalling pack"
+  rmDir packDir

--- a/src/Pack/Runner/Uninstall.idr
+++ b/src/Pack/Runner/Uninstall.idr
@@ -15,9 +15,9 @@ import Pack.Core.Types
 
 export covering
 uninstallPack :
-     {auto _ : HasIO io}
-  -> {auto _ : LogRef}
+     {auto _ : LogRef}
   -> {auto _ : PackDir}
+  -> {auto _ : HasIO io}
   -> EitherT PackErr io ()
 uninstallPack = do
   info "Uninstalling pack"


### PR DESCRIPTION
This PR adds a new pack command `uninstall`, which can be invoked as follows:

```
$ pack uninstall
```

This pack command deletes the `$PACK_DIR`.

This PR closes #294.