### PR TITLE
[ feature] Automating Mid-Install Temporary Directory Cleanup

### DIFF
--- a/pack.ipkg
+++ b/pack.ipkg
@@ -14,6 +14,7 @@ prebuild = "bash version.sh"
 postbuild = "bash restore.sh"
 
 depends = base >= 0.6.0
+        , async
         , elab-util
         , filepath
         , getopts

--- a/pack.ipkg
+++ b/pack.ipkg
@@ -13,7 +13,7 @@ prebuild = "bash version.sh"
 
 postbuild = "bash restore.sh"
 
-depends = base >= 0.6.0
+depends = base >= 0.7.0
         , async
         , elab-util
         , filepath

--- a/src/Pack/Config/Environment.idr
+++ b/src/Pack/Config/Environment.idr
@@ -396,8 +396,8 @@ getPackDir = do
 
 ||| Update the package database.
 export
-updateDB : HasIO io => TmpDir => PackDir => EitherT PackErr io ()
-updateDB = do
+updateDB : HasIO io => PackDir => (_ : TmpDir) -> EitherT PackErr io ()
+updateDB td = do
   rmDir dbDir
   commit <- gitLatest dbRepo "main"
   withGit packDB dbRepo commit $ \d =>
@@ -428,9 +428,9 @@ copyLatest = do
 ||| Loads the name of the default collection (currently the latest
 ||| nightly)
 export
-defaultColl : HasIO io => TmpDir => PackDir => EitherT PackErr io DBName
-defaultColl = do
-  when !(missing dbDir) updateDB
+defaultColl : HasIO io => PackDir => (td : TmpDir) -> EitherT PackErr io DBName
+defaultColl td = do
+  when !(missing dbDir) (updateDB td)
   latestCollection dbDir
 
 ||| Resolve a meta commit by fetching the hash of the latest commit
@@ -464,12 +464,12 @@ getConfig :
   -> {auto _   : Command c}
   -> {auto _   : HasIO io}
   -> {auto pd  : PackDir}
-  -> {auto td  : TmpDir}
   -> {auto cur : CurDir}
+  -> (td : TmpDir)
   -> EitherT PackErr io (MetaConfig, CommandWithArgs c)
-getConfig c = do
+getConfig c td = do
   -- relevant directories
-  coll       <- defaultColl
+  coll       <- defaultColl td
 
   -- Initialize `pack.toml` if none exists
   when !(fileMissing globalPackToml) $
@@ -537,12 +537,12 @@ pkgs = fromList $ (\c => (corePkgName c, Core c)) <$> corePkgs
 export covering
 loadDB :
      {auto _ : HasIO io}
-  -> {auto _ : TmpDir}
   -> {auto _ : PackDir}
   -> MetaConfig
+  -> (td : TmpDir)
   -> EitherT PackErr io MetaDB
-loadDB mc = do
-  when !(missing dbDir) updateDB
+loadDB mc td = do
+  when !(missing dbDir) (updateDB td)
   debug "reading package collection"
   raw <- readFromTOML MetaDB dbFile
   case fileStem dbFile of
@@ -635,14 +635,14 @@ export covering
 env :
      {auto _   : HasIO io}
   -> {auto pd  : PackDir}
-  -> {auto td  : TmpDir}
   -> {auto ch  : LibCache}
   -> {auto lbf : LineBufferingCmd}
   -> (mc       : MetaConfig)
   -> (fetch    : Bool)
+  -> (td       : TmpDir)
   -> EitherT PackErr io Env
-env mc fetch = do
-  mdb <- loadDB mc
+env mc fetch td = do
+  mdb <- loadDB mc td
   db  <- traverseDB (resolveMeta fetch) mdb
   c   <- traverse (resolveMeta fetch) db.idrisURL mc
 

--- a/src/Pack/Core/IO.idr
+++ b/src/Pack/Core/IO.idr
@@ -305,6 +305,7 @@ findInAllParentDirs p = go [] where
       Just parentD => go nextRes $ assert_smaller currD parentD
       Nothing      => pure nextRes
 
+export
 mkTmpDir : HasIO io => PackDir => EitherT PackErr io TmpDir
 mkTmpDir = go 100 0
 
@@ -334,6 +335,15 @@ withTmpDir :
   -> EitherT PackErr io a
 withTmpDir f = do
   td <- mkTmpDir
+  finally (rmDir tmpDir) f
+
+export
+withTmpDir' :
+     {auto _ : HasIO io}
+  -> {auto _ : TmpDir}
+  -> (TmpDir => EitherT PackErr io a)
+  -> EitherT PackErr io a
+withTmpDir' f =
   finally (rmDir tmpDir) f
 
   --------------------------------------------------------------------------------

--- a/src/Pack/Runner.idr
+++ b/src/Pack/Runner.idr
@@ -3,6 +3,9 @@ module Pack.Runner
 import Data.List.Quantifiers
 import Data.IORef
 import Data.SortedMap
+import IO.Async.Signal
+import IO.Async.Type
+import IO.Async.Util
 import Pack.CmdLn
 import Pack.CmdLn.Completion
 import Pack.Config
@@ -137,45 +140,49 @@ isFetch _     = False
 export covering
 runCmd : HasIO io => EitherT PackErr io ()
 runCmd = do
-  pd <- getPackDir
-  withTmpDir $ do
-    cd       <- CD <$> curDir
-    cache    <- emptyCache
-    (mc,cmd) <- getConfig Cmd
-    let fetch := isFetch (fst cmd)
-    linebuf  <- getLineBufferingCmd
-    case cmd of
-      (Completion ** [a,b])     => env mc fetch >>= complete a b
-      (CompletionScript ** [f]) => putStrLn (completionScript f)
-      (Query  ** [MkQ m s])     => env mc fetch >>= query m s
-      (Fuzzy ** [MkFQ m s])     => idrisEnv mc fetch >>= fuzzy m s
-      (UpdateDB ** [])          => updateDB
-      (CollectGarbage ** [])    => env mc fetch >>= garbageCollector
-      (Run ** [p,args])         => idrisEnv mc fetch >>= runApp !(refinePkg p) args
-      (Test ** [p,args])        => idrisEnv mc fetch >>= runTest p args
-      (Exec ** [p,args])        => idrisEnv mc fetch >>= exec p args
-      (Repl ** [p])             => idrisEnv mc fetch >>= idrisRepl p
-      (Build ** [p])            => idrisEnv mc fetch >>= build !(refinePkg p)
-      (BuildDeps ** [p])        => idrisEnv mc fetch >>= buildDeps !(refinePkg p)
-      (Typecheck ** [p])        => idrisEnv mc fetch >>= typecheck !(refinePkg p)
-      (Clean ** [p])            => idrisEnv mc fetch >>= clean !(refinePkg p)
-      (CleanBuild ** [p])       => do p <- refinePkg p
-                                      e <- idrisEnv mc fetch
-                                      clean p e >> build p e
-      (PrintHelp ** [c])        => putStrLn (usageDesc c)
-      (Install ** [ps])         => idrisEnv mc fetch >>= \e => installLibs ps
-      (Remove ** [ps])          => idrisEnv mc fetch >>= \e => removeLibs ps
-      (InstallApp ** [ps])      => idrisEnv mc fetch >>= \e => installApps ps
-      (RemoveApp ** [ps])       => idrisEnv mc fetch >>= \e => removeApps ps
-      (Update ** [])            => idrisEnv mc fetch >>= update
-      (Fetch ** [])             => idrisEnv mc fetch >>= \e => install []
-      (PackagePath ** [])       => env mc fetch >>= packagePathDirs >>= putStrLn
-      (LibsPath ** [])          => env mc fetch >>= packageLibDirs  >>= putStrLn
-      (DataPath ** [])          => env mc fetch >>= packageDataDirs >>= putStrLn
-      (AppPath ** [n])          => env mc fetch >>= appPath n
-      (Info ** [])              => env mc fetch >>= printInfo
-      (New ** [pty,p])          => idrisEnv mc fetch >>= new cd pty p
-      (Switch ** [db])          => do
-        env <- idrisEnv mc fetch
-        install []
-        writeCollection
+  pd  <- getPackDir
+  td  <- mkTmpDir
+  liftIO $ syncApp $ ignore $ race
+    [ onSignal SigINT (liftIO $ run $ rmDir tmpDir)
+    , liftIO $ run $ withTmpDir' $ do
+        cd       <- CD <$> curDir
+        cache    <- emptyCache
+        (mc,cmd) <- getConfig Cmd td
+        let fetch := isFetch (fst cmd)
+        linebuf  <- getLineBufferingCmd
+        case cmd of
+          (Completion ** [a,b])     => env mc fetch td >>= complete a b
+          (CompletionScript ** [f]) => putStrLn (completionScript f)
+          (Query  ** [MkQ m s])     => env mc fetch td >>= query m s
+          (Fuzzy ** [MkFQ m s])     => idrisEnv mc fetch td >>= fuzzy m s
+          (UpdateDB ** [])          => updateDB td
+          (CollectGarbage ** [])    => env mc fetch td >>= garbageCollector
+          (Run ** [p,args])         => idrisEnv mc fetch td >>= runApp !(refinePkg p) args
+          (Test ** [p,args])        => idrisEnv mc fetch td >>= runTest p args
+          (Exec ** [p,args])        => idrisEnv mc fetch td >>= exec p args
+          (Repl ** [p])             => idrisEnv mc fetch td >>= idrisRepl p
+          (Build ** [p])            => idrisEnv mc fetch td >>= build !(refinePkg p)
+          (BuildDeps ** [p])        => idrisEnv mc fetch td >>= buildDeps !(refinePkg p)
+          (Typecheck ** [p])        => idrisEnv mc fetch td >>= typecheck !(refinePkg p)
+          (Clean ** [p])            => idrisEnv mc fetch td >>= clean !(refinePkg p)
+          (CleanBuild ** [p])       => do p <- refinePkg p
+                                          e <- idrisEnv mc fetch td
+                                          clean p e >> build p e
+          (PrintHelp ** [c])        => putStrLn (usageDesc c)
+          (Install ** [ps])         => idrisEnv mc fetch td >>= \e => installLibs ps
+          (Remove ** [ps])          => idrisEnv mc fetch td >>= \e => removeLibs ps
+          (InstallApp ** [ps])      => idrisEnv mc fetch td >>= \e => installApps ps
+          (RemoveApp ** [ps])       => idrisEnv mc fetch td >>= \e => removeApps ps
+          (Update ** [])            => idrisEnv mc fetch td >>= update
+          (Fetch ** [])             => idrisEnv mc fetch td >>= \e => install []
+          (PackagePath ** [])       => env mc fetch td >>= packagePathDirs >>= putStrLn
+          (LibsPath ** [])          => env mc fetch td >>= packageLibDirs  >>= putStrLn
+          (DataPath ** [])          => env mc fetch td >>= packageDataDirs >>= putStrLn
+          (AppPath ** [n])          => env mc fetch td >>= appPath n
+          (Info ** [])              => env mc fetch td >>= printInfo
+          (New ** [pty,p])          => idrisEnv mc fetch td >>= new cd pty p
+          (Switch ** [db])          => do
+            env <- idrisEnv mc fetch td
+            install []
+            writeCollection
+    ]

--- a/src/Pack/Runner/Install.idr
+++ b/src/Pack/Runner/Install.idr
@@ -410,13 +410,13 @@ export covering
 idrisEnv :
      {auto _ : HasIO io}
   -> {auto _ : PackDir}
-  -> {auto _ : TmpDir}
   -> {auto _ : LibCache}
   -> {auto _ : LineBufferingCmd}
   -> MetaConfig
   -> (fetch : Bool)
+  -> (td : TmpDir)
   -> EitherT PackErr io IdrisEnv
-idrisEnv mc fetch = env mc fetch >>= (\e => mkIdris)
+idrisEnv mc fetch td = env mc fetch td >>= (\e => mkIdris)
 
 ||| Update the pack installation
 export covering


### PR DESCRIPTION
This PR adds cleans up temporary directories that used to linger after a mid-install Ctrl+C.

To accomplish this, the [idris2-async](https://github.com/stefan-hoeck/idris2-async) library is utilized to race two threads:
1. `SigINT` listener thread.
2. Driver thread.

This PR closes #288.