### PR TITLE
[ re #270 ] Make `extra-args` work more appropriately

### DIFF
--- a/src/Pack/CmdLn/Opts.idr
+++ b/src/Pack/CmdLn/Opts.idr
@@ -61,7 +61,7 @@ setRlwrap : Maybe String -> AdjConf
 setRlwrap args _ = Right . {rlwrap := UseRlwrap $ maybe [] (\s => [NoEscape s]) args}
 
 addExtraArgs : String -> AdjConf
-addExtraArgs args _ = Right . {extraArgs $= (<+> PassExtraArgs [NoEscape args])}
+addExtraArgs args _ = Right . {extraArgs $= (++ [NoEscape args])}
 
 setIpkg : String -> AdjConf
 setIpkg v (CD dir) c = case readAbsFile dir v of

--- a/src/Pack/CmdLn/Opts.idr
+++ b/src/Pack/CmdLn/Opts.idr
@@ -60,8 +60,8 @@ setBootstrap b _ = Right . {bootstrap := b}
 setRlwrap : Maybe String -> AdjConf
 setRlwrap args _ = Right . {rlwrap := UseRlwrap $ maybe [] (\s => [NoEscape s]) args}
 
-setExtraArgs : String -> AdjConf
-setExtraArgs args _ = Right . {extraArgs := PassExtraArgs [NoEscape args]}
+addExtraArgs : String -> AdjConf
+addExtraArgs args _ = Right . {extraArgs $= (<+> PassExtraArgs [NoEscape args])}
 
 setIpkg : String -> AdjConf
 setIpkg v (CD dir) c = case readAbsFile dir v of
@@ -189,7 +189,7 @@ descs =
       """
   , MkOpt [] ["rlwrap"]   (OptArg setRlwrap "<rlwrap args>")
       "Run a REPL session in `rlwrap`."
-  , MkOpt [] ["extra-args"] (ReqArg setExtraArgs "<idris2 args>")
+  , MkOpt [] ["extra-args"] (ReqArg addExtraArgs "<idris2 args>")
       "Any extra arguments to pass to Idris2."
   , MkOpt ['v'] ["verbose"]   (NoArg debug)
       "Print debugging information"

--- a/src/Pack/Config/Environment.idr
+++ b/src/Pack/Config/Environment.idr
@@ -350,9 +350,7 @@ buildEnv =
 ||| Idris executable with extra arguments, if they are present in the config.
 export
 idrisCmd : (e : Env) => CmdArgList
-idrisCmd = case e.config.extraArgs of
-             NoExtraArgs      => [idrisExec]
-             PassExtraArgs as => idrisExec :: as
+idrisCmd = idrisExec :: e.config.extraArgs
 
 ||| Idris executable to use together with the
 ||| `--cg` (codegen) command line option.

--- a/src/Pack/Config/Environment.idr
+++ b/src/Pack/Config/Environment.idr
@@ -127,8 +127,10 @@ export %inline
 idrisBinDir : PackDir => DB => Path Abs
 idrisBinDir = idrisPrefixDir /> "bin"
 
-||| Location of the Idris2 executable used to build
-||| packages.
+||| Location of the Idris2 executable used to build packages.
+|||
+||| Notice that if you need an Idris command, you may need `idrisCmd` function
+||| instead because it takes extra arguments into account.
 export
 idrisExec : PackDir => DB => File Abs
 idrisExec = MkF idrisBinDir "idris2"
@@ -345,13 +347,20 @@ buildEnv =
   let pre := if useRacket then [("IDRIS2_CG", "racket")] else []
    in (pre ++ ) <$> sequence [packagePath, libPath, dataPath]
 
+||| Idris executable with extra arguments, if they are present in the config.
+export
+idrisCmd : (e : Env) => CmdArgList
+idrisCmd = case e.config.extraArgs of
+             NoExtraArgs      => [idrisExec]
+             PassExtraArgs as => idrisExec :: as
+
 ||| Idris executable to use together with the
 ||| `--cg` (codegen) command line option.
 export
 idrisWithCG : (e : Env) => CmdArgList
 idrisWithCG = case e.config.codegen of
-  Default => [idrisExec]
-  cg      => [idrisExec, "--cg", cg]
+  Default => idrisCmd
+  cg      => idrisCmd ++ ["--cg", cg]
 
 ||| Idris executable loading the given package plus the
 ||| environment variables needed to run it.

--- a/src/Pack/Config/TOML.idr
+++ b/src/Pack/Config/TOML.idr
@@ -37,10 +37,10 @@ FromTOML RlwrapConfig where
   fromTOML _ _ = Left $ WrongType [] "boolean, string or array of strings"
 
 export
-FromTOML ExtraIdris2ArgsConfig where
-  fromTOML _ (TStr str)  = Right $ PassExtraArgs [NoEscape str]
+FromTOML CmdArgList where
+  fromTOML _ (TStr str)  = Right $ [NoEscape str]
   fromTOML _ (TArr _ xs) =
-    PassExtraArgs . fromStrList <$>
+    fromStrList <$>
       traverse (extractString "array of strings") (xs <>> [])
   fromTOML _ _ = Left $ WrongType [] "string or array of strings"
 

--- a/src/Pack/Config/Types.idr
+++ b/src/Pack/Config/Types.idr
@@ -134,21 +134,6 @@ data RlwrapConfig : Type where
   DoNotUseRlwrap : RlwrapConfig
   UseRlwrap      : CmdArgList -> RlwrapConfig
 
-||| Data type describing additional options to the `idris2` executable.
-|||
-||| It is isomoprhic to `Maybe CmdArgList`.
-||| See the docs for `RlwrapConfig` for the rationale behind the dedicated type.
-public export
-data ExtraIdris2ArgsConfig : Type where
-  NoExtraArgs   : ExtraIdris2ArgsConfig
-  PassExtraArgs : CmdArgList -> ExtraIdris2ArgsConfig
-
-export
-Semigroup ExtraIdris2ArgsConfig where
-  NoExtraArgs <+> rhs = rhs
-  PassExtraArgs a1 <+> NoExtraArgs = PassExtraArgs a1
-  PassExtraArgs a1 <+> PassExtraArgs a2 = PassExtraArgs $ a1 <+> a2
-
 ||| Type-level identity
 public export
 0 I : Type -> Type
@@ -230,7 +215,7 @@ record Config_ (f : Type -> Type) (c : Type) where
   rlwrap       : f RlwrapConfig
 
   ||| Any extra arguments to pass to Idris2 executable.
-  extraArgs    : f ExtraIdris2ArgsConfig
+  extraArgs    : f CmdArgList
 
   ||| Libraries to install automatically
   autoLibs     : f (List PkgName)
@@ -367,7 +352,7 @@ init coll = MkConfig {
   , useKatla        = False
   , withIpkg        = Search cur
   , rlwrap          = DoNotUseRlwrap
-  , extraArgs       = NoExtraArgs
+  , extraArgs       = []
   , autoLibs        = []
   , autoApps        = []
   , autoLoad        = NoPkgs
@@ -401,7 +386,7 @@ update ci cm = MkConfig {
   , useKatla        = fromMaybe ci.useKatla cm.useKatla
   , withIpkg        = fromMaybe ci.withIpkg cm.withIpkg
   , rlwrap          = fromMaybe ci.rlwrap cm.rlwrap
-  , extraArgs       = ci.extraArgs <+> fromMaybe NoExtraArgs cm.extraArgs
+  , extraArgs       = ci.extraArgs <+> fromMaybe [] cm.extraArgs
   , whitelist       = sortedNub (ci.whitelist ++ concat cm.whitelist)
   , autoLibs        = sortedNub (ci.autoLibs ++ concat cm.autoLibs)
   , autoApps        = sortedNub (ci.autoApps ++ concat cm.autoApps)

--- a/src/Pack/Runner/Develop.idr
+++ b/src/Pack/Runner/Develop.idr
@@ -71,11 +71,8 @@ replOpts mf = do
       cgOpt  := case cg of
                   Default => []
                   _       => ["--cg", cg]
-      extraArgs := case e.env.config.extraArgs of
-                        NoExtraArgs => []
-                        PassExtraArgs args => args
   install libs
-  pure (srcDir ++ cgOpt ++ pkgs ++ extraArgs, cg, mp)
+  pure (srcDir ++ cgOpt ++ pkgs, cg, mp)
 
 -- return the path of an Idris source file to an `.ipkg` file.
 srcFileRelativeToIpkg : (ipkg,idr : Maybe (File Abs)) -> CmdArgList


### PR DESCRIPTION
PR #270 introduces `--extra-args` option enabling us to pass additional arguments to the compiler. But this options works in an unexpected way sometimes: e.g.
- it is fully ignored in commands like `build`, `cleanbuild` and, I think, `install`;
- extra args from local `pack.toml`s are stacked together, but only the last CLI option is taken into account.

What I propose is to pass extra-args to each call to the compiler (except for the very special internal calls of `pack` to the compiler using `idrisExec` function directly) so that any current and future command would respect this option. Also, I propose to take all passed extra arguments into account.

The only change that I made and I'm not certain about is the order: currently for the REPL options, where now `--extra-args` are used, those options are in the right of `pack`'s own options, while I made them to be on the left. I personally think this is, actually, good, since we don't want user extra options to fiddle or override options that are important to `pack` itself. But this behaviour may break current behaviour is case of existing abuse of `--extra-args` option.