### PR TITLE
[ fix ] don't use stdbuf if it is broken

### DIFF
--- a/src/Pack/Config/Environment.idr
+++ b/src/Pack/Config/Environment.idr
@@ -525,6 +525,9 @@ getLineBufferingCmd = findCmd variants
       0 <- system $ escapeCmd
              ["type", cmd, NoEscape ">", "/dev/null", NoEscape "2>", "/dev/null"]
         | _ => findCmd rest
+      0 <- system $ escapeCmd
+             [ cmd, "-oL", "ls", NoEscape ">", "/dev/null", NoEscape "2>", "/dev/null"]
+        | _ => findCmd rest
       pure $ MkLineBufferingCmd $ [cmd] ++ args
 
     variants : List (String, CmdArgList)


### PR DESCRIPTION
It came up in a discussion  with @joelberkeley on discord that the homebrew `stdbuf` does not work in github `macos-latest` containers.  It fails complaining about an architecture mismatch:
```
dyld[2194]: tried: '/opt/homebrew/Cellar/coreutils/9.5/libexec/coreutils/libstdbuf.so' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e')), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/coreutils/9.5/libexec/coreutils/libstdbuf.so' (no such file), '/opt/homebrew/Cellar/coreutils/9.5/libexec/coreutils/libstdbuf.so' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e'))
```
This breaks pack in macos-latest containers if coreutils is installed.

This PR changes the code in pack that locates `stdbuf` to also verify that it successfully runs before deciding to use it.  (Locally, I added a `putStrLn` to verify that it still uses `stdbuf` if it is present and working.)
