### PR TITLE
Introduce package "notices"

### DIFF
--- a/src/Pack/Admin/Report/Types.idr
+++ b/src/Pack/Admin/Report/Types.idr
@@ -59,12 +59,12 @@ apiLink p =
   "https://stefan-hoeck.github.io/idris2-pack-db/docs/\{p}/docs/index.html"
 
 url : (e : Env) => Package -> URL
-url (Git u _ _ _ _)            = u
+url (Git u _ _ _ _ _)            = u
 url (Local dir ipkg pkgPath _) = MkURL "\{dir}"
 url (Core _)                   = e.db.idrisURL
 
 commit : (e : Env) => Package -> Commit
-commit (Git _ c _ _ _)            = c
+commit (Git _ c _ _ _ _)            = c
 commit (Local dir ipkg pkgPath _) = ""
 commit (Core _)                   = e.db.idrisCommit
 

--- a/src/Pack/Admin/Runner/Check.idr
+++ b/src/Pack/Admin/Runner/Check.idr
@@ -43,7 +43,7 @@ test (RL pkg n d _ _) =
   case e.env.config.skipTests of
     True  => pure Skipped
     False => case  pkg of
-      Git u c _ _ (Just t) => do
+      Git u c _ _ (Just t) _ => do
         d <- withGit n u c pure
         runIpkg (d </> t) [] e
         pure TestSuccess

--- a/src/Pack/Config/Environment.idr
+++ b/src/Pack/Config/Environment.idr
@@ -157,7 +157,7 @@ idrisDataDir = idrisInstallDir /> "support"
 ||| Directory where an installed library or app goes
 export %inline
 pkgPrefixDir : PackDir => DB => PkgName -> Package -> Path Abs
-pkgPrefixDir n (Git _ c _ _ _) = commitDir <//> n <//> c
+pkgPrefixDir n (Git _ c _ _ _ _) = commitDir <//> n <//> c
 pkgPrefixDir n (Local _ _ _ _) = commitDir </> "local" <//> n
 pkgPrefixDir n (Core _)        = idrisPrefixDir
 
@@ -219,7 +219,7 @@ pkgInstallDir n p d =
       dir  := pkgPrefixDir n p /> idrisDir
    in case p of
         Core c        => dir /> (c <-> vers)
-        Git _ _ _ _ _ => dir </> pkgRelDir d
+        Git _ _ _ _ _ _ => dir </> pkgRelDir d
         Local _ _ _ _ => dir </> pkgRelDir d
 
 ||| Directory where the API docs of the package will be installed.
@@ -577,7 +577,7 @@ cacheCoreIpkgFiles dir = for_ corePkgs $ \c =>
 
 export
 notCached : HasIO io => (e : Env) => PkgName -> Package -> io Bool
-notCached n (Git u c i _ _) = fileMissing $ ipkgCachePath n c i
+notCached n (Git u c i _ _ _) = fileMissing $ ipkgCachePath n c i
 notCached n (Local d i _ _) = pure False
 notCached n (Core c)        = fileMissing $ coreCachePath c
 
@@ -588,7 +588,7 @@ cachePkg :
   -> PkgName
   -> Package
   -> EitherT PackErr io ()
-cachePkg n (Git u c i _ _) =
+cachePkg n (Git u c i _ _ _) =
   let cache  := ipkgCachePath n c i
       tmpLoc := gitTmpDir n </> i
    in withGit n u c $ \dir => do

--- a/src/Pack/Database/TOML.idr
+++ b/src/Pack/Database/TOML.idr
@@ -21,6 +21,7 @@ git f v =
        (valAt "ipkg" f v)
        (optValAt "packagePath" f False v)
        (maybeValAt "test" f v)
+       (maybeValAt "notice" f v)
   |]
 
 local : File Abs -> TomlValue -> Either TOMLErr (Package_ c)

--- a/src/Pack/Runner/Database.idr
+++ b/src/Pack/Runner/Database.idr
@@ -181,9 +181,9 @@ withPkgEnv :
   -> Package
   -> (Path Abs -> EitherT PackErr io a)
   -> EitherT PackErr io a
-withPkgEnv n (Git u c i _ _) f = withGit n u c f
-withPkgEnv n (Local d i _ _) f = inDir d f
-withPkgEnv n (Core _)        f = withCoreGit f
+withPkgEnv n (Git u c i _ _ _) f = withGit n u c f
+withPkgEnv n (Local d i _ _)   f = inDir d f
+withPkgEnv n (Core _)          f = withCoreGit f
 
 isOutdated : DPair Package PkgStatus -> Bool
 isOutdated (fst ** Outdated) = True
@@ -265,7 +265,7 @@ loadIpkg :
   -> PkgName
   -> Package
   -> EitherT PackErr io (Desc U)
-loadIpkg n (Git u c i _ _) =
+loadIpkg n (Git u c i _ _ _) =
   let cache  := ipkgCachePath n c i
       tmpLoc := gitTmpDir n </> i
    in parseIpkgFile cache tmpLoc

--- a/src/Pack/Runner/Develop.idr
+++ b/src/Pack/Runner/Develop.idr
@@ -184,7 +184,7 @@ runTest :
   -> EitherT PackErr io ()
 runTest n args e = case lookup n allPackages of
   Nothing                     => throwE (UnknownPkg n)
-  Just (Git u c _ _ $ Just t) => do
+  Just (Git u c _ _ (Just t) _) => do
     d <- withGit n u c pure
     runIpkg (d </> t) args e
   Just (Local d _ _ $ Just t) => runIpkg (d </> t) args e

--- a/src/Pack/Runner/Install.idr
+++ b/src/Pack/Runner/Install.idr
@@ -253,7 +253,7 @@ preInstall :
 preInstall rl = withPkgEnv rl.name rl.pkg $ \dir =>
   let ipkgAbs := ipkg dir rl.pkg
    in case rl.pkg of
-        Git u c ipkg _ _ => do
+        Git u c ipkg _ _ _ => do
           let cache := ipkgCachePath rl.name c ipkg
           copyFile cache ipkgAbs
         Local _ _ _ _ => pure ()
@@ -308,7 +308,7 @@ installApp b ra =
       let ipkgAbs := ipkg dir ra.pkg
        in case ra.pkg of
             Core _            => pure ()
-            Git u c ipkg pp _ => do
+            Git u c ipkg pp _ _ => do
               let cache   := ipkgCachePath ra.name c ipkg
               copyFile cache ipkgAbs
               libPkg [] Build True ["--build"] (notPackIsSafe ra.desc)

--- a/src/Pack/Runner/Install.idr
+++ b/src/Pack/Runner/Install.idr
@@ -222,6 +222,10 @@ withSrcStr = case c.withSrc of
   True  => " (with sources)"
   False => ""
 
+maybeGiveNotice : HasIO io => Config => SafeLib -> io ()
+maybeGiveNotice (RL (Git _ _ _ _ _ (Just notice)) _ _ _ _) = warn notice
+maybeGiveNotice _ = pure ()
+
 installImpl :
      {auto _ : HasIO io}
   -> {auto e : IdrisEnv}
@@ -234,6 +238,7 @@ installImpl dir rl =
       libDir   := rl.desc.path.parent </> "lib"
    in do
      info "Installing library\{withSrcStr}: \{name rl}"
+     maybeGiveNotice rl
      when (isInstalled rl) $ do
        info "Removing currently installed version of \{name rl}"
        rmDir (pkgInstallDir rl.name rl.pkg rl.desc)

--- a/src/Pack/Runner/Query.idr
+++ b/src/Pack/Runner/Query.idr
@@ -147,25 +147,27 @@ appStatus qp = case qp.app of
     , "App          : \{status' st}"
     ]
 
-testFile : Maybe (File Rel) -> List String
-testFile Nothing  = []
-testFile (Just f) = ["Test File    : \{f}"]
+testFile : Maybe (File Rel) -> Maybe String
+testFile = map (\f => "Test File    : \{f}")
+
+notice : Maybe String -> Maybe String
+notice = map (\f =>   "Notice       : \{f}")
 
 details : QPkg -> List String
 details qp = case qp.lib.pkg of
-  Git url commit ipkg _ t => [
+  Git url commit ipkg _ t n => [
     "Type         : Git project"
   , "URL          : \{url}"
   , "Commit       : \{commit}"
   , "ipkg File    : \{ipkg}"
-  ] ++ testFile t
+  ] ++ (catMaybes [testFile t, notice n])
 
   Local d i _ t =>
     let ipkg := toAbsFile d i
      in [ "Type         : Local Idris project"
         , "Location     : \{ipkg.parent}"
         , "ipkg File    : \{ipkg.file}"
-        ] ++ testFile t
+        ] ++ (catMaybes [testFile t])
 
   Core _            => [
     "Type         : Idris core package"


### PR DESCRIPTION
I'm putting this implementation up for discussion. I don't know  if the feature is desirable or if the name "notice" is the best choice.

The idea is that a package that was previously submitted to the `pack` collection might become defunct or have other important caveats worth telling users of the package about. For example, I want to move the `FVect` type from my `fvect` package into the `containers` package. I'm not deleting the `FVect` repository and there's no immediate need to remove it from the pack database -- removing it would potentially break downstream projects without warning. Instead, I would like to archive the GitHub repository and add a "notice" to the pack database entry that instructs consumers to find `FVect` in the `containers` package instead.

I especially don't know the most effective place in pack's various processes to surface this notice to the end-user of pack so I just picked a spot that gets hit when installing a package.