### PR TITLE
[ refactor ] use XDG_CONFIG_HOME for storing global settings

### DIFF
--- a/src/Pack/Config/TOML.idr
+++ b/src/Pack/Config/TOML.idr
@@ -78,13 +78,20 @@ FromTOML UserConfig where
           (maybeValAt "log" f v)
       |]
 
-||| Initial content of an auto-generated `PACK_DIR/user/pack.toml` file.
 export
-initToml : (scheme : String) -> (db : DBName) -> String
-initToml scheme db = """
+dbToml : (db : DBName) -> String
+dbToml db =
+  """
   # The package collection to use
   collection = "\{db}"
+  """
 
+
+||| Initial content of an auto-generated `PACK_DIR/user/pack.toml` file.
+export
+initToml : (scheme : String) -> String
+initToml scheme =
+  """
   [install]
 
   # Whether to install packages together with their

--- a/src/Pack/Core/Types.idr
+++ b/src/Pack/Core/Types.idr
@@ -125,8 +125,24 @@ export
 Cast (File t) (Path t) where cast = toPath
 
 ----------------------------------------------------------------------------------
-----          CurDir, PackDir, and TmpDir
+----          XDGDir, CurDir, PackDir, and TmpDir
 ----------------------------------------------------------------------------------
+
+||| Corresponds to `$XDG_CONFIG_HOME/pack`. Defaults to `$HOME/.config/pack`.
+public export
+data XDGDir : Type where
+  [noHints]
+  XD : (dir : Path Abs) -> XDGDir
+
+export %inline
+Interpolation XDGDir where
+  interpolate (XD dir) = interpolate dir
+
+||| Use this when you need access to the `XDG_CONFIG_HOME/pack` path with
+||| only a value of type `XDGDir` in scope.
+export %inline
+xdgDir : (xd : XDGDir) => Path Abs
+xdgDir {xd = XD dir} = dir
 
 ||| The directory where package collections, global user settings,
 ||| and cached `.ipkg` files are stored.
@@ -668,6 +684,9 @@ data PackErr : Type where
   ||| Failed to get package directory path
   NoPackDir  : PackErr
 
+  ||| Failed to get `$XDG_CONFIG_HOME` directory path
+  NoXDGDir   : PackErr
+
   ||| Failed to create temporary directory
   NoTmpDir  : PackErr
 
@@ -791,6 +810,12 @@ printErr NoCurDir = "Failed to get current directory."
 printErr NoPackDir = """
   Failed to figure out package directory.
   This means, that neither environment variable \"PACK_DIR\"
+  nor environment varaible \"HOME\" was set.
+  """
+
+printErr NoXDGDir = """
+  Failed to figure out the `$XDG_CONFIG_HOME` directory.
+  This means, that neither environment variable \"XDG_CONFIG_HOME\"
   nor environment varaible \"HOME\" was set.
   """
 

--- a/src/Pack/Runner.idr
+++ b/src/Pack/Runner.idr
@@ -142,6 +142,7 @@ export covering
 runCmd : HasIO io => EitherT PackErr io ()
 runCmd = do
   pd <- getPackDir
+  xd <- getXDGDir
   withTmpDir $ do
     cd       <- CD <$> curDir
     cache    <- emptyCache

--- a/src/Pack/Version.idr
+++ b/src/Pack/Version.idr
@@ -4,3 +4,4 @@ import Pack.Core.Types
 
 export %inline
 version : Commit
+version = "12f5a13977c6682f269e5f03758cea1c8e61ac77"


### PR DESCRIPTION
This addresses #321 . After this change, global (static) settings are going to be read from `$XDG_CONFIG_HOME/pack/pack.toml`, while changing settings (the pack collection) will still be stored in `$PACK_DIR/user/pack.toml`, which is also the file that is going to be overwritten by `pack switch latest`.

TODO:
- [x] Adjust core behavior
- [ ] Adjust micropack installer
- [ ] Adjust the installation script