### PR TITLE
internal: made consistent with parser refactor

### DIFF
--- a/src/Pack/Core/Ipkg.idr
+++ b/src/Pack/Core/Ipkg.idr
@@ -11,7 +11,7 @@ import Libraries.Data.String.Extra
 import Libraries.Text.Parser
 import Pack.Core.Types
 import Pack.Core.IO
-import Parser.Package
+import Idris.Parser.Core.Package
 import System.File
 
 %default total


### PR DESCRIPTION
changed the file to be correct with the new code 

> [!WARNING]
> This should only be pulled ***after*** [the main change](https://github.com/idris-lang/Idris2/pull/3652) 