### PR TITLE
Fix typos in help text and comments

### DIFF
--- a/src/Pack/CmdLn/Opts.idr
+++ b/src/Pack/CmdLn/Opts.idr
@@ -124,7 +124,7 @@ descs =
       "Print a dependency tree of a package known to pack"
   , MkOpt [] ["reverse-tree"]   (NoArg $ setQuery ReverseTree)
       """
-      Print a tree of packages depending on a package know to pack.
+      Print a tree of packages depending on a package known to pack.
       Use this to find all packages transitively depending on a specific
       library
       """
@@ -188,12 +188,12 @@ descs =
       """
   , MkOpt [] ["warn-depends"]   (NoArg $ setWarnDepends True)
       """
-      Issue a warning in precense of a local `depends` directory, which might
+      Issue a warning in presence of a local `depends` directory, which might
       interfere with the libraries managed by pack.
       """
   , MkOpt [] ["no-warn-depends"]   (NoArg $ setWarnDepends False)
       """
-      Don't issue a warning in precense of a local `depends` directory.
+      Don't issue a warning in presence of a local `depends` directory.
       """
   , MkOpt [] ["skip-tests"]   (NoArg $ setSkipTests True)
       """

--- a/src/Pack/Config/Types.idr
+++ b/src/Pack/Config/Types.idr
@@ -34,7 +34,7 @@ data Autoload : Type where
   AutoPkgs  : List PkgName -> Autoload
 
   ||| Use the given explicit list of packages even in the
-  ||| precense of an `.ipkg` file.
+  ||| presence of an `.ipkg` file.
   ForcePkgs : List PkgName -> Autoload
 
 ||| What to show when querying the data base
@@ -199,7 +199,7 @@ record Config_ (f : Type -> Type) (c : Type) where
   ||| match the current one.
   gcPurge : f Bool
 
-  ||| Whether to issue a warning in precense of a local `depends` directory
+  ||| Whether to issue a warning in presence of a local `depends` directory
   warnDepends : f Bool
 
   ||| Whether to skip tests during collection checking


### PR DESCRIPTION
Noticed two typos: "know to pack" should be "known to pack", and in several places "precense" should be "presence"