### PR TITLE
Stop `pack.toml` aggregation on `PermissionDenied`

### DIFF
--- a/src/Pack/Core/IO.idr
+++ b/src/Pack/Core/IO.idr
@@ -300,19 +300,21 @@ export
 findInAllParentDirs :  {auto _ : HasIO io}
   -> (Body -> Bool)
   -> Path Abs
-  -> EitherT PackErr io $ List $ File Abs
-findInAllParentDirs p = go [] where
-  go : List (File Abs) -> Path Abs -> EitherT PackErr io $ List $ File Abs
-  go presentRes currD = do
-    Just af <-
-      catchE
-        (findInParentDirs p currD)
-        (handlePermissionDenied presentRes)
-      | Nothing => pure presentRes
-    let nextRes = af::presentRes
-    case parentDir $ parent af of
-      Just parentD => go nextRes $ assert_smaller currD parentD
-      Nothing      => pure nextRes
+  -> EitherT PackErr io (List (File Abs))
+findInAllParentDirs p = go []
+
+  where
+    go : List (File Abs) -> Path Abs -> EitherT PackErr io (List (File Abs))
+    go presentRes currD = do
+      Just af <-
+        catchE
+          (findInParentDirs p currD)
+          (handlePermissionDenied presentRes)
+        | Nothing => pure presentRes
+      let nextRes := af::presentRes
+      case parentDir $ parent af of
+        Just parentD => go nextRes $ assert_smaller currD parentD
+        Nothing      => pure nextRes
 
       where
         -- If we get a PermissionDenied FileError when some `pack.toml` where

--- a/src/Pack/Core/IO.idr
+++ b/src/Pack/Core/IO.idr
@@ -295,6 +295,7 @@ findInParentDirs p (PAbs d sb) = go sb
 
 ||| Tries to find the first file, the body of which return `True` for
 ||| the given predicate, in each parent directory.
+||| Will stop the aggregation at the first encountered `PermissionDenied`.
 export
 findInAllParentDirs :  {auto _ : HasIO io}
   -> (Body -> Bool)
@@ -303,12 +304,28 @@ findInAllParentDirs :  {auto _ : HasIO io}
 findInAllParentDirs p = go [] where
   go : List (File Abs) -> Path Abs -> EitherT PackErr io $ List $ File Abs
   go presentRes currD = do
-    Just af <- findInParentDirs p currD
+    Just af <-
+      catchE
+        (findInParentDirs p currD)
+        (handlePermissionDenied presentRes)
       | Nothing => pure presentRes
     let nextRes = af::presentRes
     case parentDir $ parent af of
       Just parentD => go nextRes $ assert_smaller currD parentD
       Nothing      => pure nextRes
+
+      where
+        -- If we get a PermissionDenied FileError when some `pack.toml` where
+        -- already found, then we simply pretend that `findInParentDirs`
+        -- couldn't find anything above. Otherwise we forward the error.
+        -- (See github #386)
+        handlePermissionDenied :
+             (presentRes : List (File Abs))
+          -> PackErr
+          -> EitherT PackErr io (Maybe (File Abs))
+        handlePermissionDenied (_::_) (DirEntries path PermissionDenied) =
+          pure Nothing
+        handlePermissionDenied _ err = throwE err
 
 mkTmpDir : HasIO io => (pd : PackDirs) => EitherT PackErr io TmpDir
 mkTmpDir = go 100 0


### PR DESCRIPTION
Hello,

I went ahead and spent some time to do the change I need for #386.

There are two commits, the first one is the actual change (1f9126e84652379a73ac011401afee4b26156b58). I tried to follow your style guide, but I still have some unknowns, I'll write about it later, and the second one follows the campsite rule as suggested from the Idris2 contributing. (That's a bit of a reach, but since you mentioned working on transferring the projects to match the style guide, I might as well contribute a bit more. :) )

I tested the change by building `pack` with the global install of `pack`, then using the local version to rebuild `pack` with restricted access, full access, and no access at all.
I noticed that with no access at all, `pack` is started at `/`, and in that case `findInParentDirs` doesn't even try to find a `pack.toml`. That's fine because no one develops in the root folder (I think), but I guess I didn't expect that `/` being represented with the empty `SnocList` would have this kind of side effect.
Also, with restricted access, no warning is emitted that an access restriction was encountered. That's normal given my implementation, but if it's important, it will complexify a lot the change needed.

Regarding the unknowns about styling,
1. I've put the `catchE` handler in a `where` clause indented with `go` as the baseline. (I prefer it this way, `findInAllParentDirs > go > handlePermissionDenied` as `handlePermissionDenied` is a detail from `go` and putting it at the same level would mean placing `handlePermissionDenied` between `findInAllParentDirs` and `go`
2. I originally used the form ``action `catchE` handler``, it made the line too long, but a simple line return was sufficient to match the line length rule, I'm curious about your opinion on this, compared to the current alternative
   ```idris
   catchE
     action
     handler
   ```
3. linked to the `catchE` formatting is the pattern matching bind. In `findInParentDirs`
   ```idris
   (h :: _) <- filter p <$> entries dir | Nil => go sb
   ```
   is used, and in `findInAllParentDirs`
   ```idris
       Just af <- findInParentDirs p currD
         | Nothing => pure presentRes
   ```
   is used when
   ```idris
       Just af <- findInParentDirs p currD | Nothing => pure presentRes
   ```
   would have been fine.
   But for my case, it is necessarily multiline, so I'm curious what is you opinion on that.
4. There is no guideline on the type syntax around using parens or `$`. From playing around in my personal project `<|` also works with one level of nesting, but fails otherwise because it isn't special syntax contrary  to `$`. That does make me think `$` could fail in the future. Anyway, seeing what's in your style guide and in the `pack` project, I changed the type signature of `findInAllParentDirs` to use parens.

I am of course open to suggestion :), but if you find this is fine as is and wish to merge it, let me know for me to squash the styling before merging (I'm pretty certain github can't autosquash from a quick google search).

I can also update the style of `findInParentDirs` if you want, since it is related to the current changes (I had to play with it to make sure I understood what was going on).

cheers