### PR TITLE
fix: add enum installation needed for ilex

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -170,6 +170,18 @@ pushd "$CLONES_DIR/idris2-literal"
 "$BOOT_PATH" --install literal.ipkg
 popd
 
+# Install finite
+git clone --depth=1 https://github.com/stefan-hoeck/idris2-finite.git "$CLONES_DIR/idris2-finite"
+pushd "$CLONES_DIR/idris2-finite"
+"$BOOT_PATH" --install finite.ipkg
+popd
+
+# Install enum
+git clone --depth=1 https://github.com/stefan-hoeck/idris2-enum.git "$CLONES_DIR/idris2-enum"
+pushd "$CLONES_DIR/idris2-enum"
+"$BOOT_PATH" --install enum.ipkg
+popd
+
 # Install ilex-core, ilex, and ilex-toml
 
 git clone --depth=1 https://github.com/stefan-hoeck/idris2-ilex.git "$CLONES_DIR/idris2-ilex"


### PR DESCRIPTION
Hi, the installation script was failing due to the new dependency on enum (and transitively finite) in ilex

## Confirmation

- [x] I confirm that this contribution did not involve generative AI nor large language models.
