### PR TITLE
[ipkg] add two missing packages

### DIFF
--- a/pack.ipkg
+++ b/pack.ipkg
@@ -27,6 +27,7 @@ modules = Pack.CmdLn
 
         , Pack.Config
         , Pack.Config.Environment
+        , Pack.Config.Environment.Variable
         , Pack.Config.TOML
         , Pack.Config.Types
 
@@ -51,6 +52,7 @@ modules = Pack.CmdLn
         , Pack.Runner.Install
         , Pack.Runner.New
         , Pack.Runner.Query
+        , Pack.Runner.Uninstall
 
         , Pack.Version
 


### PR DESCRIPTION
There are two modules in pack's directory tree that are not listed in the `ipkg`:
`Pack.Config.Environment.Variable` and `Pack.Runner.Uninstall`.

This causes an error when building an executable of a separate project which uses `pack` as a library (for instance, if it imports `Pack.Core.IO`)
```
[ build ] Now compiling the executable: projectName
Error: Module Pack.Config.Environment.Variable not found

[ fatal ] Error when executing system command.

```

## Confirmation

- [x] I confirm that this contribution did not involve generative AI nor large language models.
